### PR TITLE
feat: Send refined images to the screen

### DIFF
--- a/Sudoku/photoSudoku.storyboard
+++ b/Sudoku/photoSudoku.storyboard
@@ -30,6 +30,7 @@
                     </view>
                     <connections>
                         <outlet property="cameraView" destination="cLG-Qq-7gK" id="3EJ-eq-Spp"/>
+                        <outlet property="refinedView" destination="aep-Ba-2AR" id="Vx1-kn-Ca8"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/Sudoku/photoSudokuViewController.swift
+++ b/Sudoku/photoSudokuViewController.swift
@@ -11,6 +11,7 @@ import AVFoundation
 final class photoSudokuViewController: UIViewController, AVCaptureVideoDataOutputSampleBufferDelegate {
     
     @IBOutlet weak var cameraView: UIImageView!
+    @IBOutlet weak var refinedView: UIImageView!
     
     private var session: AVCaptureSession?
     private var previewLayer: AVCaptureVideoPreviewLayer?
@@ -55,7 +56,7 @@ final class photoSudokuViewController: UIViewController, AVCaptureVideoDataOutpu
         }
         
     }
-
+    
     /*
     // MARK: - Navigation
 

--- a/Sudoku/photoSudokuViewController.swift
+++ b/Sudoku/photoSudokuViewController.swift
@@ -57,14 +57,68 @@ final class photoSudokuViewController: UIViewController, AVCaptureVideoDataOutpu
         
     }
     
+    
+    // 비디오 프레임이 들어올 때마다 갱신됨
     /*
-    // MARK: - Navigation
+     참고
+     https://developer.apple.com/documentation/avfoundation/avcapturevideodataoutputsamplebufferdelegate/1385775-captureoutput
+     */
+    func captureOutput(_ output: AVCaptureOutput, didOutput buffer: CMSampleBuffer, from connection: AVCaptureConnection) {
 
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+        /*
+         https://developer.apple.com/documentation/coremedia/1489236-cmsamplebuffergetimagebuffer
+         */
+        //CMSampleBuffer를 CVImageBuffer로 변환시켜준다.
+        let CVimageBuffer = CMSampleBufferGetImageBuffer(buffer)!
+        
+        /*
+         CVPixelBufferLockBaseAddress:
+         https://developer.apple.com/documentation/corevideo/1457128-cvpixelbufferlockbaseaddress
+         픽셀의 주소를 고정시켜준다.
+         */
+        CVPixelBufferLockBaseAddress(CVimageBuffer, CVPixelBufferLockFlags(rawValue: CVOptionFlags(0)))
+        //이미지의 넓이 구하기
+        let width = CVPixelBufferGetWidth(CVimageBuffer)
+        let height = CVPixelBufferGetHeight(CVimageBuffer)
+        
+        //이미지에서 사용되는 각각의 Component가 사용하는 비트 수 선언
+        let bitsPerComponent = 8
+        
+        //이미지의 row에 있는 바이트를 구한다.
+        let bytesRow = CVPixelBufferGetBytesPerRow(CVimageBuffer)
+        
+        //이미지의 주소값을 구한다.
+        let imageAddress = CVPixelBufferGetBaseAddress(CVimageBuffer)!
+        
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        
+        //비트 연산자 or 을 이용해 비트를 정리한다.
+        let bitmap = CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
+        let context = CGContext(data: imageAddress, width: width, height: height, bitsPerComponent: bitsPerComponent, bytesPerRow: bytesRow, space:  colorSpace, bitmapInfo: bitmap)
+        if let newContext = context {
+            let frame = newContext.makeImage()
+            DispatchQueue.main.async {
+                let img = UIImage(cgImage: frame!)
+                // crop
+                let w = img.size.width
+                let r = CGRect(x: 0, y: 0, width: w, height: w)
+                let imgCrop = img.cgImage?.cropping(to: r)
+                let refinedImage = UIImage(cgImage: imgCrop!)
+                
+                self.toRefinedView(refinedImage)
+            }
+        }
+        //사용했던 픽셀 주소의 고정을 풀고 재사용이 가능하도록 한다.
+        CVPixelBufferUnlockBaseAddress(CVimageBuffer, CVPixelBufferLockFlags(rawValue: CVOptionFlags(0)))
     }
+
+    func toRefinedView(_ capturedImage: UIImage) {
+        refinedView.image = capturedImage
+    }
+
+    /*
+     https://stijnoomes.com/access-camera-pixels-with-av-foundation/
+     참고
     */
 
 }


### PR DESCRIPTION
@LeeSungNo-ian

## Outline
- #5 

## Work Contents
-  스토리보드와 뷰컨 refinedView 연결
-  catureOutput 선언과 뷰와 연결

## Trouble Point 
### 1.  Converting `CVPixelBuffer` to `UIImage`(`CVPixelBuffer`를 `UIImage`로 변환해야됩니다..)
  - **Trouble Situation**
    - Should be converted using `CGContext`(변환하려면 `CGContext`를 사용해야됩니다.)
<img width="752" alt="image" src="https://user-images.githubusercontent.com/63584245/189542582-59c07f87-8277-4381-b63b-3b5bfebf9eac.png">

  - **Trouble Shooting**
    -  The `UnsafeMutableRawPointer` requires a memory address value. The address value was obtained by fixing the image address of the pixel using the `CVPixelBufferLockBaseAddress`.(`UnsafeMutableRawPointer`에는 메모리 주소 값이 필요합니다. 주소 값은 'CVPixelBufferLockBaseAddress'를 사용하여 픽셀의 이미지 주소를 고정하여 얻었습니다.)
```swift
CVPixelBufferLockBaseAddress(CVimageBuffer, CVPixelBufferLockFlags(rawValue: CVOptionFlags(0)))
```
   -  `CGColorSpace` hat specifies how to interpret a color value for display. The space was designated using `CGColorSpaceCreateDeviceRGB`, but I used this function because I thought it was not important for this project, although color values may appear differently for each device.(`CGColorSpace`는 디스플레이에 색상을 표현하는 방법을 지정해주어야합니다 . 그래서 `CGColorSpace`를 'CGColorSpaceCreateDeviceRGB'를 이용해 기기의 값을 사용하도록 지정했습니다. 기기마다 색값이 다르게 나타날 수 있지만 이번 프로젝트에서는 중요하지 않다고 생각이 들어 이 기능을 사용했습니다.
```swift
let colorSpace = CGColorSpaceCreateDeviceRGB()
```
   -  Bitmap graphics are image representations drawn by a combination of pixels. Set the premultiplied ARGB via the `premultipliedFirst` in `CGImageAlphaInfo` and the byeorder via the `byeOrder32Big` in the `CGBitmapInfo`. And use it in combination using the `bit OR operator`.(비트맵은 픽셀의 조합으로 그려진 이미지 표현방법입니다. CGImageAlphaInfo의 'premultiplevedFirst'를 통해 RGBA 값을, CGBitmapInfo의 'byOrder32Big'를 통해 byteorder를 설정해줍니다. 그리고 '비트 OR 연산자'를 사용하여 조합하여 사용했습니다.)
```swift
let bitmap = CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
```




