### PR TITLE
feat: Add progress when sudoku pool is in progress

### DIFF
--- a/Sudoku/photoSudoku.storyboard
+++ b/Sudoku/photoSudoku.storyboard
@@ -34,12 +34,32 @@
                                 <rect key="frame" x="14" y="432" width="380" height="380"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </imageView>
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IIn-3o-zDo">
+                                <rect key="frame" x="14" y="432" width="380" height="380"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <subviews>
+                                    <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="ns0-sa-9Nc">
+                                        <rect key="frame" x="140" y="140" width="101" height="101"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    </activityIndicatorView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="현재 스도쿠를 풀이 중입니다." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gdb-tc-lTc">
+                                        <rect key="frame" x="93" y="295" width="195" height="21"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                     <connections>
+                        <outlet property="activityIndicator" destination="ns0-sa-9Nc" id="plT-XG-B0r"/>
                         <outlet property="cameraView" destination="cLG-Qq-7gK" id="3EJ-eq-Spp"/>
+                        <outlet property="loadingView" destination="IIn-3o-zDo" id="sPG-ga-gl1"/>
                         <outlet property="refinedView" destination="aep-Ba-2AR" id="Vx1-kn-Ca8"/>
                         <outlet property="shooting" destination="fgX-J8-1nV" id="HX8-Xv-CvC"/>
                     </connections>

--- a/Sudoku/photoSudokuViewController.swift
+++ b/Sudoku/photoSudokuViewController.swift
@@ -64,8 +64,7 @@ final class photoSudokuViewController: UIViewController, AVCaptureVideoDataOutpu
     }
     private func cameraStop(){
         session?.stopRunning()
-        activityIndicator.startAnimating()
-        loadingView.isHidden = false
+        showIndicator()
     }
     
     private func preparedSession() {

--- a/Sudoku/photoSudokuViewController.swift
+++ b/Sudoku/photoSudokuViewController.swift
@@ -15,11 +15,7 @@ final class photoSudokuViewController: UIViewController, AVCaptureVideoDataOutpu
     @IBOutlet weak var cameraView: UIImageView!
     @IBOutlet weak var refinedView: UIImageView!
     @IBOutlet weak var shooting: UIButton!
-    @IBOutlet weak var loadingView: UIView! {
-        didSet {
-            loadingView.layer.cornerRadius = 6
-        }
-    }
+    @IBOutlet weak var loadingView: UIView!
     @IBOutlet weak var activityIndicator: UIActivityIndicatorView!
     
     private var session: AVCaptureSession?

--- a/Sudoku/photoSudokuViewController.swift
+++ b/Sudoku/photoSudokuViewController.swift
@@ -15,6 +15,12 @@ final class photoSudokuViewController: UIViewController, AVCaptureVideoDataOutpu
     @IBOutlet weak var cameraView: UIImageView!
     @IBOutlet weak var refinedView: UIImageView!
     @IBOutlet weak var shooting: UIButton!
+    @IBOutlet weak var loadingView: UIView! {
+        didSet {
+            loadingView.layer.cornerRadius = 6
+        }
+    }
+    @IBOutlet weak var activityIndicator: UIActivityIndicatorView!
     
     private var session: AVCaptureSession?
     private var previewLayer: AVCaptureVideoPreviewLayer?
@@ -24,6 +30,7 @@ final class photoSudokuViewController: UIViewController, AVCaptureVideoDataOutpu
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        hideIndicator()
         preparedSession()
         session?.startRunning()
         
@@ -41,7 +48,14 @@ final class photoSudokuViewController: UIViewController, AVCaptureVideoDataOutpu
             check = true
         }
     }
-    
+    private func showIndicator() {
+        activityIndicator.startAnimating()
+        loadingView.isHidden = false
+    }
+    private func hideIndicator() {
+        activityIndicator.stopAnimating()
+        loadingView.isHidden = true
+    }
     private func sudokuSolvingQueue() {
         self.recognizeNum(image: refinedView.image!)
     }
@@ -50,6 +64,8 @@ final class photoSudokuViewController: UIViewController, AVCaptureVideoDataOutpu
     }
     private func cameraStop(){
         session?.stopRunning()
+        activityIndicator.startAnimating()
+        loadingView.isHidden = false
     }
     
     private func preparedSession() {
@@ -92,7 +108,7 @@ final class photoSudokuViewController: UIViewController, AVCaptureVideoDataOutpu
      참고
      https://developer.apple.com/documentation/avfoundation/avcapturevideodataoutputsamplebufferdelegate/1385775-captureoutput
      */
-    private func captureOutput(_ output: AVCaptureOutput, didOutput buffer: CMSampleBuffer, from connection: AVCaptureConnection) {
+    internal func captureOutput(_ output: AVCaptureOutput, didOutput buffer: CMSampleBuffer, from connection: AVCaptureConnection) {
         //기기의 현재 방향에 따라 화면의 방향도 돌려준다.
         connection.videoOrientation = AVCaptureVideoOrientation.portrait
         
@@ -203,8 +219,10 @@ final class photoSudokuViewController: UIViewController, AVCaptureVideoDataOutpu
                 alret.addAction(yes)
                 present(alret, animated: true, completion: nil)
                 session?.startRunning()
+                hideIndicator()
                 return
             }
+            hideIndicator()
             // 풀어진 sudoku 표시
             showNum(solvedSudokuArray, sudokuArray, image)
             

--- a/Sudoku/photoSudokuViewController.swift
+++ b/Sudoku/photoSudokuViewController.swift
@@ -48,20 +48,25 @@ final class photoSudokuViewController: UIViewController, AVCaptureVideoDataOutpu
             check = true
         }
     }
+    
     private func showIndicator() {
         activityIndicator.startAnimating()
         loadingView.isHidden = false
     }
+    
     private func hideIndicator() {
         activityIndicator.stopAnimating()
         loadingView.isHidden = true
     }
+    
     private func sudokuSolvingQueue() {
         self.recognizeNum(image: refinedView.image!)
     }
+    
     private func cameraStart(){
         session?.startRunning()
     }
+    
     private func cameraStop(){
         session?.stopRunning()
         showIndicator()
@@ -100,7 +105,6 @@ final class photoSudokuViewController: UIViewController, AVCaptureVideoDataOutpu
         }
         
     }
-    
     
     // 비디오 프레임이 들어올 때마다 갱신됨
     /*
@@ -167,7 +171,6 @@ final class photoSudokuViewController: UIViewController, AVCaptureVideoDataOutpu
             refinedView.image = detectRectangle[1] as? UIImage
         }
     }
-    
     
     private func recognizeNum(image: UIImage) {
         // get sudoku number images

--- a/Sudoku/pickerSudoku.storyboard
+++ b/Sudoku/pickerSudoku.storyboard
@@ -39,11 +39,31 @@
                                 <rect key="frame" x="43" y="116" width="328" height="329"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </imageView>
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rcG-lM-I8B">
+                                <rect key="frame" x="43" y="116" width="328" height="329"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <subviews>
+                                    <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="ZY0-lj-P2r">
+                                        <rect key="frame" x="154" y="154" width="20" height="20"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    </activityIndicatorView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="현재 스도쿠를 풀이 중 입니다." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zCI-FB-75G">
+                                        <rect key="frame" x="65" y="252" width="199" height="21"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.3035873724489796" colorSpace="custom" customColorSpace="sRGB"/>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                     <connections>
+                        <outlet property="activityIndicator" destination="ZY0-lj-P2r" id="V8g-3B-a8w"/>
+                        <outlet property="loadingView" destination="rcG-lM-I8B" id="zDp-rX-ed7"/>
                         <outlet property="photoPicker" destination="9Ve-0d-0vw" id="zvj-tB-9FI"/>
                         <outlet property="pickerImage" destination="UYs-1J-XfZ" id="p6y-DT-TZy"/>
                         <outlet property="solSudoku" destination="gwM-Lj-KAn" id="6if-lk-l0Q"/>

--- a/Sudoku/pickerSudokuViewController.swift
+++ b/Sudoku/pickerSudokuViewController.swift
@@ -14,6 +14,8 @@ class pickerSudokuViewController: UIViewController {
     @IBOutlet weak var photoPicker: UIButton!
     @IBOutlet weak var solSudoku: UIButton!
     
+    @IBOutlet weak var activityIndicator: UIActivityIndicatorView!
+    @IBOutlet weak var loadingView: UIView!
     @IBOutlet weak var pickerImage: UIImageView!
     
     
@@ -23,6 +25,7 @@ class pickerSudokuViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        hideIndicator()
         picker.delegate = self
         // Do any additional setup after loading the view.
     }
@@ -46,6 +49,7 @@ class pickerSudokuViewController: UIViewController {
     
     @IBAction func shootSolSudoku(_ sender: Any) {
         if pickerImage.image != nil {
+            showIndicator()
             sudokuSolvingWorkItem = DispatchWorkItem(block: self.sudokuSolvingQueue)
             DispatchQueue.main.async(execute: sudokuSolvingWorkItem!)
         } else {
@@ -58,6 +62,15 @@ class pickerSudokuViewController: UIViewController {
             alret.addAction(yes)
             present(alret, animated: true, completion: nil)
         }
+    }
+    
+    private func showIndicator() {
+        activityIndicator.startAnimating()
+        loadingView.isHidden = false
+    }
+    private func hideIndicator() {
+        activityIndicator.stopAnimating()
+        loadingView.isHidden = true
     }
     
     private func sudokuSolvingQueue() {
@@ -114,8 +127,10 @@ class pickerSudokuViewController: UIViewController {
                 alret.addAction(no)
                 alret.addAction(yes)
                 present(alret, animated: true, completion: nil)
+                hideIndicator()
                 return
             }
+            hideIndicator()
             // 풀어진 sudoku 표시
             showNum(solvedSudokuArray, sudokuArray, image)
         }

--- a/Sudoku/pickerSudokuViewController.swift
+++ b/Sudoku/pickerSudokuViewController.swift
@@ -68,6 +68,7 @@ class pickerSudokuViewController: UIViewController {
         activityIndicator.startAnimating()
         loadingView.isHidden = false
     }
+    
     private func hideIndicator() {
         activityIndicator.stopAnimating()
         loadingView.isHidden = true
@@ -135,7 +136,6 @@ class pickerSudokuViewController: UIViewController {
             showNum(solvedSudokuArray, sudokuArray, image)
         }
     }
-    
     
     private func showNum(_ sudoku: [[Int]], _ solSudoku: [[Int]], _ image: UIImage) {
         UIGraphicsBeginImageContext(pickerImage.bounds.size)

--- a/Sudoku/sudokuCalculation.swift
+++ b/Sudoku/sudokuCalculation.swift
@@ -33,9 +33,8 @@ func isVerify(_ number: Int, _ sudoku: [[Int]], _ row: Int, _ col:Int) -> Bool {
 
 func sudokuCalcuation(_ sudoku: inout [[Int]], _ row: Int, _ col: Int, _ check: inout Int) -> Bool {
     
-    if(check >= 700000){
-        return false
-    }
+    if(check >= 700000) { return false }
+    
     if (row == 9) { return true }
 
     // 기존에 존재하는 숫자가 있다면

--- a/Sudoku/sudokuCalculation.swift
+++ b/Sudoku/sudokuCalculation.swift
@@ -32,7 +32,8 @@ func isVerify(_ number: Int, _ sudoku: [[Int]], _ row: Int, _ col:Int) -> Bool {
 }
 
 func sudokuCalcuation(_ sudoku: inout [[Int]], _ row: Int, _ col: Int, _ check: inout Int) -> Bool {
-    if(check >= 500000){
+    
+    if(check >= 700000){
         return false
     }
     if (row == 9) { return true }


### PR DESCRIPTION
@LeeSungNo-ian
@jeong-hyeonHwang
@commitcomplete


## Outline
- #21 

## Work Contents
-  progress 추가


## Trouble Point 
### 1.  When Sudoku Pool is in progress, the user does not know that the pool is in progress.(스도쿠 풀이가 진행 중일때 사용자는 풀이가 진행 중인것을 알 수 없음.)

  - **Trouble Situation**
    -  The progress must be lost when Sudoku Pool fails and when it succeeds(스도쿠 풀이가 실패했을 때와 성공했을 때 모두 progress가 없어져야됨)

 - **Trouble Shooting**
    - Create and control a view containing progress and a function to manage progress(progress가 담긴 뷰와 progress를 관리하는 함수를 만들어 컨트롤)
```swift
private func showIndicator() {
        activityIndicator.startAnimating()
        loadingView.isHidden = false
    }
    private func hideIndicator() {
        activityIndicator.stopAnimating()
        loadingView.isHidden = true
    }
```

<img width="240" alt="image" src="https://user-images.githubusercontent.com/63584245/191015845-a166dc1e-9e20-4f61-beec-9550cf21a38c.jpg">
