### PR TITLE
feat: P2 SwiftUI 앱 셸 전환 시작

### DIFF
--- a/Sudoku.xcodeproj/project.pbxproj
+++ b/Sudoku.xcodeproj/project.pbxproj
@@ -30,6 +30,10 @@
 		D5A7B5DD28F1F1AB007721B3 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A7B5DC28F1F1AB007721B3 /* String+.swift */; };
 		D5BBD65F28D205AE00747F15 /* pickerSudoku.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D5BBD65E28D205AE00747F15 /* pickerSudoku.storyboard */; };
 		D5BBD66128D205C900747F15 /* pickerSudokuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5BBD66028D205C900747F15 /* pickerSudokuViewController.swift */; };
+		206FF9097CC54F3793D53F05 /* SudokuApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A6F9DDC9A7412C921F3A55 /* SudokuApp.swift */; };
+		ADD35F8812894B7682087DFD /* AppCompositionRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A68014A1C3743FC8FBE6D78 /* AppCompositionRoot.swift */; };
+		7195192E125E4EB2BA79BA7F /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A32C9C89994B8EB042895F /* HomeView.swift */; };
+		EA0CF3C74F10472AB150953A /* LegacyFlowContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E714D572C729490D979D5E31 /* LegacyFlowContainerView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -88,6 +92,10 @@
 		D5A7B5DC28F1F1AB007721B3 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		D5BBD65E28D205AE00747F15 /* pickerSudoku.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = pickerSudoku.storyboard; sourceTree = "<group>"; };
 		D5BBD66028D205C900747F15 /* pickerSudokuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = pickerSudokuViewController.swift; sourceTree = "<group>"; };
+		56A6F9DDC9A7412C921F3A55 /* SudokuApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SudokuApp.swift; sourceTree = "<group>"; };
+		8A68014A1C3743FC8FBE6D78 /* AppCompositionRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCompositionRoot.swift; sourceTree = "<group>"; };
+		47A32C9C89994B8EB042895F /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
+		E714D572C729490D979D5E31 /* LegacyFlowContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyFlowContainerView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -123,6 +131,8 @@
 		D53F618328C77AE20017D756 /* Sudoku */ = {
 			isa = PBXGroup;
 			children = (
+				10F06A296FD34C2AB79FF443 /* App */,
+				68CF7C85CF4B45D3AAC10ED7 /* FeatureHome */,
 				D5A7B5CE28F1F033007721B3 /* Localizable */,
 				D58069BD28E5D13B00461CD8 /* StoryBoard */,
 				D58069BC28E5D10D00461CD8 /* ViewController */,
@@ -138,6 +148,24 @@
 				D597D1D528CF765D00694D66 /* Sudoku-Bridging-Header.h */,
 			);
 			path = Sudoku;
+			sourceTree = "<group>";
+		};
+		10F06A296FD34C2AB79FF443 /* App */ = {
+			isa = PBXGroup;
+			children = (
+				56A6F9DDC9A7412C921F3A55 /* SudokuApp.swift */,
+				8A68014A1C3743FC8FBE6D78 /* AppCompositionRoot.swift */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
+		68CF7C85CF4B45D3AAC10ED7 /* FeatureHome */ = {
+			isa = PBXGroup;
+			children = (
+				47A32C9C89994B8EB042895F /* HomeView.swift */,
+				E714D572C729490D979D5E31 /* LegacyFlowContainerView.swift */,
+			);
+			path = FeatureHome;
 			sourceTree = "<group>";
 		};
 		D58069B928E5D0BD00461CD8 /* DL */ = {
@@ -302,11 +330,15 @@
 				D5BBD66128D205C900747F15 /* pickerSudokuViewController.swift in Sources */,
 				D58069B828E5C96F00461CD8 /* UIColor+.swift in Sources */,
 				D597D1D728CF765D00694D66 /* wrapper.mm in Sources */,
+				EA0CF3C74F10472AB150953A /* LegacyFlowContainerView.swift in Sources */,
 				D597D1E528D0DF3200694D66 /* UIImage+.swift in Sources */,
 				D597D1BA28CDFFEA00694D66 /* sudokuCalculation.swift in Sources */,
 				D53F618928C77AE20017D756 /* ViewController.swift in Sources */,
+				206FF9097CC54F3793D53F05 /* SudokuApp.swift in Sources */,
 				D53F619F28C77C070017D756 /* importSudokuViewController.swift in Sources */,
+				7195192E125E4EB2BA79BA7F /* HomeView.swift in Sources */,
 				D53F618528C77AE20017D756 /* AppDelegate.swift in Sources */,
+				ADD35F8812894B7682087DFD /* AppCompositionRoot.swift in Sources */,
 				D597D1E228CFBBCA00694D66 /* model_64.mlpackage in Sources */,
 				D58069B628E4A19300461CD8 /* CALayer+.swift in Sources */,
 				D5A7B5DD28F1F1AB007721B3 /* String+.swift in Sources */,
@@ -511,7 +543,6 @@
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = NSPhotoLibraryUsageDescription;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
@@ -552,7 +583,6 @@
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = NSPhotoLibraryUsageDescription;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;

--- a/Sudoku/App/AppCompositionRoot.swift
+++ b/Sudoku/App/AppCompositionRoot.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct AppCompositionRoot {
+    private let legacyFactory: LegacyFlowViewControllerFactory
+
+    init(legacyFactory: LegacyFlowViewControllerFactory = .init()) {
+        self.legacyFactory = legacyFactory
+    }
+
+    @ViewBuilder
+    func makeRootView() -> some View {
+        HomeView(flowFactory: legacyFactory)
+    }
+}

--- a/Sudoku/App/SudokuApp.swift
+++ b/Sudoku/App/SudokuApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct SudokuApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+    private let compositionRoot = AppCompositionRoot()
+
+    var body: some Scene {
+        WindowGroup {
+            compositionRoot.makeRootView()
+        }
+    }
+}

--- a/Sudoku/AppDelegate.swift
+++ b/Sudoku/AppDelegate.swift
@@ -7,30 +7,9 @@
 
 import UIKit
 
-@main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
         return true
     }
-
-    // MARK: UISceneSession Lifecycle
-
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        // Called when a new scene session is being created.
-        // Use this method to select a configuration to create the new scene with.
-        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
-    }
-
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-    }
-
-
 }
-

--- a/Sudoku/FeatureHome/HomeView.swift
+++ b/Sudoku/FeatureHome/HomeView.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+struct HomeView: View {
+    private let flowFactory: LegacyFlowViewControllerBuilding
+
+    init(flowFactory: LegacyFlowViewControllerBuilding) {
+        self.flowFactory = flowFactory
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 20) {
+                SudokuPreviewGrid()
+                    .frame(maxWidth: 360)
+
+                VStack(spacing: 12) {
+                    ForEach(LegacyFlow.allCases, id: \.self) { flow in
+                        NavigationLink {
+                            LegacyFlowContainerView(flow: flow, factory: flowFactory)
+                                .navigationTitle(flow.title)
+                                .navigationBarTitleDisplayMode(.inline)
+                        } label: {
+                            Text(flow.title)
+                                .font(.system(size: 22, weight: .bold))
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 56)
+                                .foregroundStyle(Color.white)
+                                .background(Color(uiColor: .sudokuColor(.sudokuDeepButton)))
+                                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 12)
+            .navigationTitle("SolDoKu".localized)
+        }
+    }
+}
+
+private struct SudokuPreviewGrid: View {
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 0), count: 9)
+
+    var body: some View {
+        LazyVGrid(columns: columns, spacing: 0) {
+            ForEach(0..<81, id: \.self) { index in
+                Rectangle()
+                    .fill(Color.white)
+                    .overlay(
+                        Rectangle()
+                            .strokeBorder(Color.black.opacity(0.9), lineWidth: borderWidth(for: index))
+                    )
+                    .frame(height: 32)
+            }
+        }
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .stroke(Color.black, lineWidth: 2)
+        )
+    }
+
+    private func borderWidth(for index: Int) -> CGFloat {
+        let row = index / 9
+        let col = index % 9
+        if row % 3 == 0 || col % 3 == 0 {
+            return 1.5
+        }
+        return 0.5
+    }
+}

--- a/Sudoku/FeatureHome/LegacyFlowContainerView.swift
+++ b/Sudoku/FeatureHome/LegacyFlowContainerView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+import UIKit
+
+enum LegacyFlow: String, Hashable, CaseIterable {
+    case camera
+    case picker
+    case manual
+
+    var title: String {
+        switch self {
+        case .camera:
+            return "Take a Picture".localized
+        case .picker:
+            return "Import from Album".localized
+        case .manual:
+            return "Direct Input".localized
+        }
+    }
+
+    fileprivate var storyboardName: String {
+        switch self {
+        case .camera:
+            return "photoSudoku"
+        case .picker:
+            return "pickerSudoku"
+        case .manual:
+            return "importSudoku"
+        }
+    }
+
+    fileprivate var storyboardIdentifier: String {
+        switch self {
+        case .camera:
+            return "photoSudoku"
+        case .picker:
+            return "pickerSudoku"
+        case .manual:
+            return "importSudoku"
+        }
+    }
+}
+
+protocol LegacyFlowViewControllerBuilding {
+    func makeViewController(for flow: LegacyFlow) -> UIViewController
+}
+
+final class LegacyFlowViewControllerFactory: LegacyFlowViewControllerBuilding {
+    func makeViewController(for flow: LegacyFlow) -> UIViewController {
+        let storyboard = UIStoryboard(name: flow.storyboardName, bundle: nil)
+        let viewController = storyboard.instantiateViewController(withIdentifier: flow.storyboardIdentifier)
+        viewController.title = flow.title
+        return viewController
+    }
+}
+
+struct LegacyFlowContainerView: UIViewControllerRepresentable {
+    let flow: LegacyFlow
+    let factory: LegacyFlowViewControllerBuilding
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        factory.makeViewController(for: flow)
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        // no-op: this legacy screen manages its own UIKit state
+    }
+}

--- a/Sudoku/FeatureHome/LegacyFlowContainerView.swift
+++ b/Sudoku/FeatureHome/LegacyFlowContainerView.swift
@@ -47,9 +47,7 @@ protocol LegacyFlowViewControllerBuilding {
 final class LegacyFlowViewControllerFactory: LegacyFlowViewControllerBuilding {
     func makeViewController(for flow: LegacyFlow) -> UIViewController {
         let storyboard = UIStoryboard(name: flow.storyboardName, bundle: nil)
-        let viewController = storyboard.instantiateViewController(withIdentifier: flow.storyboardIdentifier)
-        viewController.title = flow.title
-        return viewController
+        return storyboard.instantiateViewController(withIdentifier: flow.storyboardIdentifier)
     }
 }
 

--- a/Sudoku/Info.plist
+++ b/Sudoku/Info.plist
@@ -2,24 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIApplicationSceneManifest</key>
-	<dict>
-		<key>UIApplicationSupportsMultipleScenes</key>
-		<false/>
-		<key>UISceneConfigurations</key>
-		<dict>
-			<key>UIWindowSceneSessionRoleApplication</key>
-			<array>
-				<dict>
-					<key>UISceneConfigurationName</key>
-					<string>Default Configuration</string>
-					<key>UISceneDelegateClassName</key>
-					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
-					<key>UISceneStoryboardFile</key>
-					<string>Main</string>
-				</dict>
-			</array>
-		</dict>
-	</dict>
 </dict>
 </plist>

--- a/planning/MIGRATION_PLAN.md
+++ b/planning/MIGRATION_PLAN.md
@@ -99,23 +99,23 @@ Last updated: 2026-02-25
 ## P2) SwiftUI 앱 셸 전환
 
 ### P2-1. 진입점 전환
-- [ ] Storyboard 기반 진입점 제거/축소
-- [ ] SwiftUI `@main App` 구성
-- [ ] Composition Root에서 의존성 주입 연결
+- [x] Storyboard 기반 진입점 제거/축소
+- [x] SwiftUI `@main App` 구성
+- [x] Composition Root에서 의존성 주입 연결
 
 ### P2-2. 홈 화면 전환
-- [ ] Home 화면을 SwiftUI로 구현
-- [ ] 기존 3개 플로우 라우팅을 SwiftUI Navigation으로 연결
-- [ ] 필요 시 임시 `UIViewControllerRepresentable` 브리지 사용
+- [x] Home 화면을 SwiftUI로 구현
+- [x] 기존 3개 플로우 라우팅을 SwiftUI Navigation으로 연결
+- [x] 필요 시 임시 `UIViewControllerRepresentable` 브리지 사용
 
 ### P2-3. 공통 UI 체계
 - [ ] `DesignSystem`에 컬러/타이포/버튼/알럿 컴포넌트 정리
 - [ ] 로컬라이제이션 키 사용 일관화
 
 ### P2 완료 기준 (DoD)
-- [ ] 앱 루트 네비게이션이 SwiftUI에서 동작
+- [x] 앱 루트 네비게이션이 SwiftUI에서 동작
 - [ ] 기존 기능 진입 동작 유지
-- [ ] Storyboard 의존성이 루트에서는 제거됨
+- [x] Storyboard 의존성이 루트에서는 제거됨
 
 ---
 


### PR DESCRIPTION
## Outline
- P2(SwiftUI 셸 전환) 착수: 앱 루트 진입점을 SwiftUI 기반으로 변경
- 기존 UIKit 플로우는 브리지 방식으로 유지하여 기능 회귀 리스크 최소화

## Work Contents
- SwiftUI `@main` 앱 진입점 추가
  - `Sudoku/App/SudokuApp.swift`
- Composition Root 추가
  - `Sudoku/App/AppCompositionRoot.swift`
- SwiftUI Home 화면 추가 + 3개 기존 플로우 라우팅 연결
  - `Sudoku/FeatureHome/HomeView.swift`
  - `Sudoku/FeatureHome/LegacyFlowContainerView.swift`
  - `UIViewControllerRepresentable` 브리지로 `photoSudoku/pickerSudoku/importSudoku` 연결
- Storyboard 루트 의존 제거
  - `Sudoku/Info.plist`의 `UIApplicationSceneManifest` 제거
  - Xcode build setting의 `INFOPLIST_KEY_UIMainStoryboardFile` 제거
  - `AppDelegate`에서 `@main` 제거 및 Scene lifecycle 코드 정리
- P2 진행상황 체크리스트 갱신
  - `planning/MIGRATION_PLAN.md`

## Test
- `swift test`
- `xcodebuild -project Sudoku.xcodeproj -scheme Sudoku -configuration Debug -destination 'generic/platform=iOS Simulator' build`
- `xcodebuild -project Sudoku.xcodeproj -scheme Sudoku -configuration Debug -destination 'generic/platform=iOS' build`
- `xcodebuild -project Sudoku.xcodeproj -scheme Sudoku -configuration Release -destination 'generic/platform=iOS Simulator' build`
- `xcodebuild -project Sudoku.xcodeproj -scheme Sudoku -configuration Release -destination 'generic/platform=iOS' build`

## Note
- `Framework/opencv2.framework.zip` 로컬 변경은 본 PR에 포함하지 않음(기존 워크트리 유지)
- 요청에 따라 본 작업은 PR 생성까지만 진행하고 merge는 대기
