### PR TITLE
feat: P2 앱 셸 잔여 작업 마무리

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -54,5 +54,9 @@ let package = Package(
                 .process("Fixtures"),
             ]
         ),
+        .testTarget(
+            name: "AppShellTests",
+            path: "Tests/AppShellTests"
+        ),
     ]
 )

--- a/Sudoku.xcodeproj/project.pbxproj
+++ b/Sudoku.xcodeproj/project.pbxproj
@@ -34,6 +34,11 @@
 		ADD35F8812894B7682087DFD /* AppCompositionRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A68014A1C3743FC8FBE6D78 /* AppCompositionRoot.swift */; };
 		7195192E125E4EB2BA79BA7F /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A32C9C89994B8EB042895F /* HomeView.swift */; };
 		EA0CF3C74F10472AB150953A /* LegacyFlowContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E714D572C729490D979D5E31 /* LegacyFlowContainerView.swift */; };
+		1F291A2BBE6941D59DAC9131 /* DSColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A116D07B6854133B294B574 /* DSColor.swift */; };
+		B3FE65FB668149CC9B26D41F /* DSTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610D4220EF7D411FA21CA32D /* DSTypography.swift */; };
+		3ECA5D66BFDD4D8A81081C53 /* DSPrimaryButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8A99487DCB44D687C9CF86 /* DSPrimaryButtonStyle.swift */; };
+		FF1F087E93434CD39F03802D /* DSAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 132E7996574B49F6AA113A3E /* DSAlert.swift */; };
+		E32331A2A15A4DDEA2BA1F7B /* L10n.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C15AB40A434EEBB2482E73 /* L10n.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -96,6 +101,11 @@
 		8A68014A1C3743FC8FBE6D78 /* AppCompositionRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCompositionRoot.swift; sourceTree = "<group>"; };
 		47A32C9C89994B8EB042895F /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		E714D572C729490D979D5E31 /* LegacyFlowContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyFlowContainerView.swift; sourceTree = "<group>"; };
+		6A116D07B6854133B294B574 /* DSColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSColor.swift; sourceTree = "<group>"; };
+		610D4220EF7D411FA21CA32D /* DSTypography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSTypography.swift; sourceTree = "<group>"; };
+		DE8A99487DCB44D687C9CF86 /* DSPrimaryButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSPrimaryButtonStyle.swift; sourceTree = "<group>"; };
+		132E7996574B49F6AA113A3E /* DSAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSAlert.swift; sourceTree = "<group>"; };
+		E1C15AB40A434EEBB2482E73 /* L10n.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = L10n.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -133,6 +143,8 @@
 			children = (
 				10F06A296FD34C2AB79FF443 /* App */,
 				68CF7C85CF4B45D3AAC10ED7 /* FeatureHome */,
+				14A493F629E44E9D89228F81 /* DesignSystem */,
+				6A94DB75402B4CA496598B40 /* Localization */,
 				D5A7B5CE28F1F033007721B3 /* Localizable */,
 				D58069BD28E5D13B00461CD8 /* StoryBoard */,
 				D58069BC28E5D10D00461CD8 /* ViewController */,
@@ -148,6 +160,25 @@
 				D597D1D528CF765D00694D66 /* Sudoku-Bridging-Header.h */,
 			);
 			path = Sudoku;
+			sourceTree = "<group>";
+		};
+		14A493F629E44E9D89228F81 /* DesignSystem */ = {
+			isa = PBXGroup;
+			children = (
+				6A116D07B6854133B294B574 /* DSColor.swift */,
+				610D4220EF7D411FA21CA32D /* DSTypography.swift */,
+				DE8A99487DCB44D687C9CF86 /* DSPrimaryButtonStyle.swift */,
+				132E7996574B49F6AA113A3E /* DSAlert.swift */,
+			);
+			path = DesignSystem;
+			sourceTree = "<group>";
+		};
+		6A94DB75402B4CA496598B40 /* Localization */ = {
+			isa = PBXGroup;
+			children = (
+				E1C15AB40A434EEBB2482E73 /* L10n.swift */,
+			);
+			path = Localization;
 			sourceTree = "<group>";
 		};
 		10F06A296FD34C2AB79FF443 /* App */ = {
@@ -331,14 +362,19 @@
 				D58069B828E5C96F00461CD8 /* UIColor+.swift in Sources */,
 				D597D1D728CF765D00694D66 /* wrapper.mm in Sources */,
 				EA0CF3C74F10472AB150953A /* LegacyFlowContainerView.swift in Sources */,
+				FF1F087E93434CD39F03802D /* DSAlert.swift in Sources */,
 				D597D1E528D0DF3200694D66 /* UIImage+.swift in Sources */,
+				1F291A2BBE6941D59DAC9131 /* DSColor.swift in Sources */,
 				D597D1BA28CDFFEA00694D66 /* sudokuCalculation.swift in Sources */,
+				E32331A2A15A4DDEA2BA1F7B /* L10n.swift in Sources */,
+				B3FE65FB668149CC9B26D41F /* DSTypography.swift in Sources */,
 				D53F618928C77AE20017D756 /* ViewController.swift in Sources */,
 				206FF9097CC54F3793D53F05 /* SudokuApp.swift in Sources */,
 				D53F619F28C77C070017D756 /* importSudokuViewController.swift in Sources */,
 				7195192E125E4EB2BA79BA7F /* HomeView.swift in Sources */,
 				D53F618528C77AE20017D756 /* AppDelegate.swift in Sources */,
 				ADD35F8812894B7682087DFD /* AppCompositionRoot.swift in Sources */,
+				3ECA5D66BFDD4D8A81081C53 /* DSPrimaryButtonStyle.swift in Sources */,
 				D597D1E228CFBBCA00694D66 /* model_64.mlpackage in Sources */,
 				D58069B628E4A19300461CD8 /* CALayer+.swift in Sources */,
 				D5A7B5DD28F1F1AB007721B3 /* String+.swift in Sources */,

--- a/Sudoku/DesignSystem/DSAlert.swift
+++ b/Sudoku/DesignSystem/DSAlert.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct DSAlertModel: Identifiable {
+    let id = UUID()
+    let title: L10nToken
+    let message: L10nToken
+    let buttonText: L10nToken
+}
+
+extension View {
+    func dsAlert(model: Binding<DSAlertModel?>) -> some View {
+        alert(
+            model.wrappedValue?.title.localized ?? "",
+            isPresented: Binding(
+                get: { model.wrappedValue != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        model.wrappedValue = nil
+                    }
+                }
+            ),
+            presenting: model.wrappedValue
+        ) { payload in
+            Button(payload.buttonText.localized, role: .cancel) {
+                model.wrappedValue = nil
+            }
+        } message: { payload in
+            Text(payload.message.localized)
+        }
+    }
+}

--- a/Sudoku/DesignSystem/DSColor.swift
+++ b/Sudoku/DesignSystem/DSColor.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+enum DSColor {
+    static let background = Color(uiColor: .systemBackground)
+    static let surface = Color.white
+    static let title = Color(uiColor: .sudokuColor(.sudokuDeepPurple))
+    static let primaryButton = Color(uiColor: .sudokuColor(.sudokuDeepButton))
+    static let primaryButtonForeground = Color.white
+    static let gridLine = Color.black.opacity(0.9)
+    static let gridBorder = Color.black
+}

--- a/Sudoku/DesignSystem/DSPrimaryButtonStyle.swift
+++ b/Sudoku/DesignSystem/DSPrimaryButtonStyle.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct DSPrimaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(DSTypography.primaryButton)
+            .frame(maxWidth: .infinity)
+            .frame(height: 56)
+            .foregroundStyle(DSColor.primaryButtonForeground)
+            .background(DSColor.primaryButton)
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
+            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+    }
+}

--- a/Sudoku/DesignSystem/DSTypography.swift
+++ b/Sudoku/DesignSystem/DSTypography.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+enum DSTypography {
+    static let heroTitle = Font.system(size: 48, weight: .heavy, design: .rounded)
+    static let primaryButton = Font.system(size: 22, weight: .bold, design: .rounded)
+    static let body = Font.system(size: 16, weight: .medium, design: .rounded)
+}

--- a/Sudoku/FeatureHome/HomeView.swift
+++ b/Sudoku/FeatureHome/HomeView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct HomeView: View {
     private let flowFactory: LegacyFlowViewControllerBuilding
+    @State private var alertModel: DSAlertModel?
 
     init(flowFactory: LegacyFlowViewControllerBuilding) {
         self.flowFactory = flowFactory
@@ -9,32 +10,60 @@ struct HomeView: View {
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 20) {
-                SudokuPreviewGrid()
-                    .frame(maxWidth: 360)
+            ZStack {
+                LinearGradient(
+                    colors: [DSColor.surface, DSColor.background],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .ignoresSafeArea()
 
-                VStack(spacing: 12) {
-                    ForEach(LegacyFlow.allCases, id: \.self) { flow in
-                        NavigationLink {
-                            LegacyFlowContainerView(flow: flow, factory: flowFactory)
-                                .navigationTitle(flow.title)
-                                .navigationBarTitleDisplayMode(.inline)
-                        } label: {
-                            Text(flow.title)
-                                .font(.system(size: 22, weight: .bold))
-                                .frame(maxWidth: .infinity)
-                                .frame(height: 56)
-                                .foregroundStyle(Color.white)
-                                .background(Color(uiColor: .sudokuColor(.sudokuDeepButton)))
-                                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                VStack(spacing: 22) {
+                    Text(L10n.Home.title.localized)
+                        .font(DSTypography.heroTitle)
+                        .foregroundStyle(DSColor.title)
+                        .minimumScaleFactor(0.8)
+
+                    SudokuPreviewGrid()
+                        .frame(maxWidth: 360)
+
+                    VStack(spacing: 12) {
+                        ForEach(LegacyFlow.allCases, id: \.self) { flow in
+                            flowNavigationButton(for: flow)
                         }
-                        .buttonStyle(.plain)
                     }
                 }
+                .padding(.horizontal, 20)
+                .padding(.top, 12)
             }
-            .padding(.horizontal, 20)
-            .padding(.top, 12)
-            .navigationTitle("SolDoKu".localized)
+            .navigationTitle(L10n.Home.title.localized)
+            .navigationBarTitleDisplayMode(.inline)
+        }
+        .dsAlert(model: $alertModel)
+    }
+
+    @ViewBuilder
+    private func flowNavigationButton(for flow: LegacyFlow) -> some View {
+        if flow.isStoryboardAvailable {
+            NavigationLink {
+                LegacyFlowContainerView(flow: flow, factory: flowFactory)
+                    .navigationTitle(flow.title.localized)
+                    .navigationBarTitleDisplayMode(.inline)
+            } label: {
+                Text(flow.title.localized)
+            }
+            .buttonStyle(DSPrimaryButtonStyle())
+        } else {
+            Button {
+                alertModel = DSAlertModel(
+                    title: L10n.Alert.routeUnavailableTitle,
+                    message: L10n.Alert.routeUnavailableMessage,
+                    buttonText: L10n.Common.confirm
+                )
+            } label: {
+                Text(flow.title.localized)
+            }
+            .buttonStyle(DSPrimaryButtonStyle())
         }
     }
 }
@@ -46,19 +75,19 @@ private struct SudokuPreviewGrid: View {
         LazyVGrid(columns: columns, spacing: 0) {
             ForEach(0..<81, id: \.self) { index in
                 Rectangle()
-                    .fill(Color.white)
+                    .fill(DSColor.surface)
                     .overlay(
                         Rectangle()
-                            .strokeBorder(Color.black.opacity(0.9), lineWidth: borderWidth(for: index))
+                            .strokeBorder(DSColor.gridLine, lineWidth: borderWidth(for: index))
                     )
                     .frame(height: 32)
             }
         }
-        .background(Color.white)
+        .background(DSColor.surface)
         .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 4, style: .continuous)
-                .stroke(Color.black, lineWidth: 2)
+                .stroke(DSColor.gridBorder, lineWidth: 2)
         )
     }
 

--- a/Sudoku/Localization/L10n.swift
+++ b/Sudoku/Localization/L10n.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+struct L10nToken: Hashable {
+    let key: String
+
+    init(_ key: String) {
+        self.key = key
+    }
+
+    var localized: String {
+        key.localized
+    }
+}
+
+enum L10n {
+    enum Home {
+        static let title = L10nToken("SolDoKu")
+        static let takePicture = L10nToken("Take a Picture")
+        static let importFromAlbum = L10nToken("Import from Album")
+        static let directInput = L10nToken("Direct Input")
+    }
+
+    enum Alert {
+        static let routeUnavailableTitle = L10nToken("Fail.")
+        static let routeUnavailableMessage = L10nToken("Please enter Sudoku.")
+    }
+
+    enum Common {
+        static let confirm = L10nToken("Confirm")
+    }
+}

--- a/Sudoku/StoryBoard/importSudoku.storyboard
+++ b/Sudoku/StoryBoard/importSudoku.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>

--- a/Sudoku/StoryBoard/photoSudoku.storyboard
+++ b/Sudoku/StoryBoard/photoSudoku.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>

--- a/Sudoku/StoryBoard/pickerSudoku.storyboard
+++ b/Sudoku/StoryBoard/pickerSudoku.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>

--- a/Tests/AppShellTests/AppShellRouteConfigTests.swift
+++ b/Tests/AppShellTests/AppShellRouteConfigTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+
+final class AppShellRouteConfigTests: XCTestCase {
+    func testLegacyFlowStoryboardsDeclareInitialViewController() throws {
+        let root = repositoryRootURL()
+        let expectedStoryboards = ["photoSudoku", "pickerSudoku", "importSudoku"]
+
+        for storyboardName in expectedStoryboards {
+            let storyboardPath = root
+                .appendingPathComponent("Sudoku")
+                .appendingPathComponent("StoryBoard")
+                .appendingPathComponent("\(storyboardName).storyboard")
+
+            let xml = try String(contentsOf: storyboardPath, encoding: .utf8)
+            XCTAssertTrue(
+                xml.contains("initialViewController=\""),
+                "\(storyboardName).storyboard must define initialViewController for SwiftUI bridge routing"
+            )
+        }
+    }
+
+    func testMainStoryboardReferencesAllLegacyFlows() throws {
+        let mainStoryboardPath = repositoryRootURL()
+            .appendingPathComponent("Sudoku")
+            .appendingPathComponent("StoryBoard")
+            .appendingPathComponent("Base.lproj")
+            .appendingPathComponent("Main.storyboard")
+        let xml = try String(contentsOf: mainStoryboardPath, encoding: .utf8)
+
+        XCTAssertTrue(xml.contains("storyboardName=\"photoSudoku\""))
+        XCTAssertTrue(xml.contains("storyboardName=\"pickerSudoku\""))
+        XCTAssertTrue(xml.contains("storyboardName=\"importSudoku\""))
+    }
+
+    private func repositoryRootURL(filePath: StaticString = #filePath) -> URL {
+        URL(fileURLWithPath: "\(filePath)")
+            .deletingLastPathComponent() // AppShellTests
+            .deletingLastPathComponent() // Tests
+            .deletingLastPathComponent() // repo root
+    }
+}

--- a/planning/MIGRATION_PLAN.md
+++ b/planning/MIGRATION_PLAN.md
@@ -22,14 +22,14 @@ Last updated: 2026-02-25
 
 ## 3) 목표 아키텍처 (모듈)
 
-- [ ] `App` (SwiftUI entry + DI composition root)
-- [ ] `DesignSystem` (색상/타이포/공통 컴포넌트)
+- [x] `App` (SwiftUI entry + DI composition root)
+- [x] `DesignSystem` (색상/타이포/공통 컴포넌트)
 - [ ] `DomainSudoku` (solver, rule validation, entities)
 - [ ] `DomainVision` (board detection / OCR protocol contracts)
 - [ ] `InfraOpenCV` (ObjC++ bridge adapter)
 - [ ] `InfraML` (CoreML adapter)
 - [ ] `InfraPermissions` (camera/photo permission service)
-- [ ] `FeatureHome` (SwiftUI)
+- [x] `FeatureHome` (SwiftUI)
 - [ ] `FeatureManualSolve` (SwiftUI)
 - [ ] `FeatureImageSolve` (SwiftUI)
 - [ ] `FeatureCameraSolve` (SwiftUI)
@@ -109,12 +109,12 @@ Last updated: 2026-02-25
 - [x] 필요 시 임시 `UIViewControllerRepresentable` 브리지 사용
 
 ### P2-3. 공통 UI 체계
-- [ ] `DesignSystem`에 컬러/타이포/버튼/알럿 컴포넌트 정리
-- [ ] 로컬라이제이션 키 사용 일관화
+- [x] `DesignSystem`에 컬러/타이포/버튼/알럿 컴포넌트 정리
+- [x] 로컬라이제이션 키 사용 일관화
 
 ### P2 완료 기준 (DoD)
 - [x] 앱 루트 네비게이션이 SwiftUI에서 동작
-- [ ] 기존 기능 진입 동작 유지
+- [x] 기존 기능 진입 동작 유지
 - [x] Storyboard 의존성이 루트에서는 제거됨
 
 ---


### PR DESCRIPTION
## Outline
- P2 잔여 작업 마감: SwiftUI 앱 셸의 공통 UI 체계 정리 및 레거시 라우팅 안전장치 보강
- Storyboard 브리지 경로를 테스트로 고정해 P2 완료 기준(기능 진입 동작 유지)을 검증 가능 상태로 전환

## Work Contents
- `DesignSystem` 추가
  - `Sudoku/DesignSystem/DSColor.swift`
  - `Sudoku/DesignSystem/DSTypography.swift`
  - `Sudoku/DesignSystem/DSPrimaryButtonStyle.swift`
  - `Sudoku/DesignSystem/DSAlert.swift`
- 로컬라이제이션 토큰 정리
  - `Sudoku/Localization/L10n.swift`
  - Home/Alert/Common 키를 토큰 기반으로 통일
- SwiftUI Home 화면에 공통 UI 적용 및 라우팅 폴백 추가
  - `Sudoku/FeatureHome/HomeView.swift`
  - `Sudoku/FeatureHome/LegacyFlowContainerView.swift`
  - storyboard 존재 여부 확인 + unavailable fallback 화면/alert 처리
- 레거시 storyboard 초기 진입점 고정
  - `Sudoku/StoryBoard/photoSudoku.storyboard`
  - `Sudoku/StoryBoard/pickerSudoku.storyboard`
  - `Sudoku/StoryBoard/importSudoku.storyboard`
  - `initialViewController` 설정 추가
- App shell 회귀 테스트 추가
  - `Tests/AppShellTests/AppShellRouteConfigTests.swift`
  - `Package.swift`에 `AppShellTests` test target 등록
- 마이그레이션 체크리스트 업데이트
  - `planning/MIGRATION_PLAN.md`의 P2 잔여 항목/DoD 반영

## Test
- `swift test`
- `xcodebuild -project Sudoku.xcodeproj -scheme Sudoku -configuration Debug -destination 'generic/platform=iOS Simulator' build`
- `xcodebuild -project Sudoku.xcodeproj -scheme Sudoku -configuration Debug -destination 'generic/platform=iOS' build`
- `xcodebuild -project Sudoku.xcodeproj -scheme Sudoku -configuration Release -destination 'generic/platform=iOS Simulator' build`
- `xcodebuild -project Sudoku.xcodeproj -scheme Sudoku -configuration Release -destination 'generic/platform=iOS' build`

## Note
- `Framework/opencv2.framework.zip` 로컬 변경은 본 PR에 포함하지 않음(기존 워크트리 유지)
- 요청에 따라 본 작업은 PR 생성까지만 진행하고 merge는 대기
