### PR TITLE
feat: P3-1 Manual Solve SwiftUI 전환 착수

### DIFF
--- a/Sudoku.xcodeproj/project.pbxproj
+++ b/Sudoku.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		3ECA5D66BFDD4D8A81081C53 /* DSPrimaryButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8A99487DCB44D687C9CF86 /* DSPrimaryButtonStyle.swift */; };
 		FF1F087E93434CD39F03802D /* DSAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 132E7996574B49F6AA113A3E /* DSAlert.swift */; };
 		E32331A2A15A4DDEA2BA1F7B /* L10n.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C15AB40A434EEBB2482E73 /* L10n.swift */; };
+		9A9B68C3A1F54D29A4A6C101 /* ManualSolveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D26E58D02A44D4A5E7C221 /* ManualSolveView.swift */; };
+		2F35E9C81A0D4E2DA03C7B11 /* ManualSolveViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D14B9C7FEF4E4B9C8B3A5522 /* ManualSolveViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -106,6 +108,8 @@
 		DE8A99487DCB44D687C9CF86 /* DSPrimaryButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSPrimaryButtonStyle.swift; sourceTree = "<group>"; };
 		132E7996574B49F6AA113A3E /* DSAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSAlert.swift; sourceTree = "<group>"; };
 		E1C15AB40A434EEBB2482E73 /* L10n.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = L10n.swift; sourceTree = "<group>"; };
+		A3D26E58D02A44D4A5E7C221 /* ManualSolveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualSolveView.swift; sourceTree = "<group>"; };
+		D14B9C7FEF4E4B9C8B3A5522 /* ManualSolveViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualSolveViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -143,6 +147,7 @@
 			children = (
 				10F06A296FD34C2AB79FF443 /* App */,
 				68CF7C85CF4B45D3AAC10ED7 /* FeatureHome */,
+				F3C9A41D1D8F4AB7A8CD9E33 /* FeatureManualSolve */,
 				14A493F629E44E9D89228F81 /* DesignSystem */,
 				6A94DB75402B4CA496598B40 /* Localization */,
 				D5A7B5CE28F1F033007721B3 /* Localizable */,
@@ -197,6 +202,15 @@
 				E714D572C729490D979D5E31 /* LegacyFlowContainerView.swift */,
 			);
 			path = FeatureHome;
+			sourceTree = "<group>";
+		};
+		F3C9A41D1D8F4AB7A8CD9E33 /* FeatureManualSolve */ = {
+			isa = PBXGroup;
+			children = (
+				A3D26E58D02A44D4A5E7C221 /* ManualSolveView.swift */,
+				D14B9C7FEF4E4B9C8B3A5522 /* ManualSolveViewModel.swift */,
+			);
+			path = FeatureManualSolve;
 			sourceTree = "<group>";
 		};
 		D58069B928E5D0BD00461CD8 /* DL */ = {
@@ -370,10 +384,12 @@
 				B3FE65FB668149CC9B26D41F /* DSTypography.swift in Sources */,
 				D53F618928C77AE20017D756 /* ViewController.swift in Sources */,
 				206FF9097CC54F3793D53F05 /* SudokuApp.swift in Sources */,
+				9A9B68C3A1F54D29A4A6C101 /* ManualSolveView.swift in Sources */,
 				D53F619F28C77C070017D756 /* importSudokuViewController.swift in Sources */,
 				7195192E125E4EB2BA79BA7F /* HomeView.swift in Sources */,
 				D53F618528C77AE20017D756 /* AppDelegate.swift in Sources */,
 				ADD35F8812894B7682087DFD /* AppCompositionRoot.swift in Sources */,
+				2F35E9C81A0D4E2DA03C7B11 /* ManualSolveViewModel.swift in Sources */,
 				3ECA5D66BFDD4D8A81081C53 /* DSPrimaryButtonStyle.swift in Sources */,
 				D597D1E228CFBBCA00694D66 /* model_64.mlpackage in Sources */,
 				D58069B628E4A19300461CD8 /* CALayer+.swift in Sources */,

--- a/Sudoku/DesignSystem/DSColor.swift
+++ b/Sudoku/DesignSystem/DSColor.swift
@@ -8,4 +8,9 @@ enum DSColor {
     static let primaryButtonForeground = Color.white
     static let gridLine = Color.black.opacity(0.9)
     static let gridBorder = Color.black
+    static let manualSelectedCell = Color(uiColor: .sudokuColor(.sudokuPurple))
+    static let manualRelatedCell = Color(uiColor: .sudokuColor(.sudokuLightPurple))
+    static let manualConflictingCell = Color(uiColor: .sudokuColor(.sudokuLightRed))
+    static let manualBlockedDigitButton = Color(uiColor: .sudokuColor(.sudokuButton))
+    static let loadingScrim = Color.black.opacity(0.3)
 }

--- a/Sudoku/FeatureHome/HomeView.swift
+++ b/Sudoku/FeatureHome/HomeView.swift
@@ -44,7 +44,16 @@ struct HomeView: View {
 
     @ViewBuilder
     private func flowNavigationButton(for flow: LegacyFlow) -> some View {
-        if flow.isStoryboardAvailable {
+        if flow == .manual {
+            NavigationLink {
+                ManualSolveView()
+                    .navigationTitle(flow.title.localized)
+                    .navigationBarTitleDisplayMode(.inline)
+            } label: {
+                Text(flow.title.localized)
+            }
+            .buttonStyle(DSPrimaryButtonStyle())
+        } else if flow.isStoryboardAvailable {
             NavigationLink {
                 LegacyFlowContainerView(flow: flow, factory: flowFactory)
                     .navigationTitle(flow.title.localized)

--- a/Sudoku/FeatureManualSolve/ManualSolveView.swift
+++ b/Sudoku/FeatureManualSolve/ManualSolveView.swift
@@ -1,0 +1,325 @@
+import SwiftUI
+
+struct ManualSolveView: View {
+    @StateObject private var viewModel: ManualSolveViewModel
+
+    init(viewModel: ManualSolveViewModel = .init()) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 18) {
+                ManualSudokuGrid(
+                    values: viewModel.board,
+                    selectedIndex: viewModel.selectedIndex,
+                    highlightedIndices: viewModel.highlightedIndices,
+                    conflictingIndices: viewModel.conflictingIndices,
+                    onTapCell: { index in
+                        if !viewModel.isSolving {
+                            viewModel.selectCell(at: index)
+                        }
+                    }
+                )
+                .frame(maxWidth: 420)
+
+                ManualKeypad(
+                    blockedDigits: viewModel.blockedDigits,
+                    isSolving: viewModel.isSolving,
+                    onTapDigit: { digit in
+                        viewModel.inputDigit(digit)
+                    },
+                    onTapClean: {
+                        viewModel.requestCleanBoard()
+                    },
+                    onTapDelete: {
+                        viewModel.deleteSelectedCellValue()
+                    },
+                    onTapSolve: {
+                        viewModel.solveButtonTapped()
+                    }
+                )
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 16)
+            .padding(.bottom, 24)
+        }
+        .background(
+            LinearGradient(
+                colors: [DSColor.surface, DSColor.background],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
+        )
+        .navigationTitle(L10n.Home.directInput.localized)
+        .navigationBarTitleDisplayMode(.inline)
+        .overlay {
+            if viewModel.isSolving {
+                ManualSolveLoadingOverlay()
+            }
+        }
+        .alert(item: $viewModel.alertKind) { alert in
+            buildAlert(for: alert)
+        }
+    }
+
+    private func buildAlert(for alert: ManualSolveViewModel.AlertKind) -> Alert {
+        switch alert {
+        case .cleanConfirm:
+            return Alert(
+                title: Text(L10n.Manual.cleanSudoku.localized),
+                message: Text(L10n.Manual.reenterSudoku.localized),
+                primaryButton: .default(Text(L10n.Common.yes.localized)) {
+                    viewModel.clearBoard()
+                },
+                secondaryButton: .destructive(Text(L10n.Common.no.localized))
+            )
+
+        case .insufficientDigits:
+            return Alert(
+                title: Text(L10n.Manual.reallyWantToSolve.localized),
+                message: Text(L10n.Manual.requiresMoreThan17.localized),
+                primaryButton: .default(Text(L10n.Common.yes.localized)) {
+                    viewModel.solveIgnoringMinimumDigits()
+                },
+                secondaryButton: .destructive(Text(L10n.Common.no.localized))
+            )
+
+        case .unsolvable:
+            return Alert(
+                title: Text(L10n.Manual.cannotSolve.localized),
+                message: Text(L10n.Manual.reenterSudoku.localized),
+                primaryButton: .default(Text(L10n.Common.yes.localized)) {
+                    viewModel.clearBoard()
+                },
+                secondaryButton: .destructive(Text(L10n.Common.no.localized))
+            )
+
+        case .emptyBoard:
+            return Alert(
+                title: Text(L10n.Manual.sudokuNotEntered.localized),
+                message: Text(L10n.Alert.routeUnavailableMessage.localized),
+                dismissButton: .default(Text(L10n.Common.confirm.localized))
+            )
+        }
+    }
+}
+
+private struct ManualSudokuGrid: View {
+    let values: [Int]
+    let selectedIndex: Int?
+    let highlightedIndices: Set<Int>
+    let conflictingIndices: Set<Int>
+    let onTapCell: (Int) -> Void
+
+    var body: some View {
+        GeometryReader { geometry in
+            let side = geometry.size.width
+            let cellSize = side / 9
+            let columns = Array(repeating: GridItem(.fixed(cellSize), spacing: 0), count: 9)
+
+            ZStack {
+                LazyVGrid(columns: columns, spacing: 0) {
+                    ForEach(0..<81, id: \.self) { index in
+                        Button {
+                            onTapCell(index)
+                        } label: {
+                            Text(displayText(for: values[index]))
+                                .font(.system(size: 24, weight: .semibold, design: .rounded))
+                                .foregroundStyle(.black)
+                                .frame(width: cellSize, height: cellSize)
+                                .background(backgroundColor(for: index))
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+
+                ManualGridLines(cellSize: cellSize)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(DSColor.gridBorder, lineWidth: 2)
+            )
+        }
+        .aspectRatio(1, contentMode: .fit)
+    }
+
+    private func displayText(for value: Int) -> String {
+        value == 0 ? "" : String(value)
+    }
+
+    private func backgroundColor(for index: Int) -> Color {
+        if selectedIndex == index {
+            return DSColor.manualSelectedCell
+        }
+
+        if conflictingIndices.contains(index) {
+            return DSColor.manualConflictingCell
+        }
+
+        if highlightedIndices.contains(index) {
+            return DSColor.manualRelatedCell
+        }
+
+        return DSColor.surface
+    }
+}
+
+private struct ManualGridLines: View {
+    let cellSize: CGFloat
+
+    var body: some View {
+        ZStack {
+            ForEach(0..<10, id: \.self) { index in
+                Path { path in
+                    let x = CGFloat(index) * cellSize
+                    path.move(to: CGPoint(x: x, y: 0))
+                    path.addLine(to: CGPoint(x: x, y: cellSize * 9))
+                }
+                .stroke(DSColor.gridBorder, lineWidth: lineWidth(for: index))
+
+                Path { path in
+                    let y = CGFloat(index) * cellSize
+                    path.move(to: CGPoint(x: 0, y: y))
+                    path.addLine(to: CGPoint(x: cellSize * 9, y: y))
+                }
+                .stroke(DSColor.gridBorder, lineWidth: lineWidth(for: index))
+            }
+        }
+    }
+
+    private func lineWidth(for index: Int) -> CGFloat {
+        index.isMultiple(of: 3) ? 2 : 0.4
+    }
+}
+
+private struct ManualKeypad: View {
+    let blockedDigits: Set<Int>
+    let isSolving: Bool
+    let onTapDigit: (Int) -> Void
+    let onTapClean: () -> Void
+    let onTapDelete: () -> Void
+    let onTapSolve: () -> Void
+
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 10), count: 4)
+    private let keypadItems: [ManualKeypadItem] = [
+        .digit(1), .digit(2), .digit(3), .action(.clean),
+        .digit(4), .digit(5), .digit(6), .action(.delete),
+        .digit(7), .digit(8), .digit(9), .action(.solve),
+    ]
+
+    var body: some View {
+        LazyVGrid(columns: columns, spacing: 10) {
+            ForEach(keypadItems, id: \.self) { item in
+                Button {
+                    tap(item)
+                } label: {
+                    Text(title(for: item))
+                        .font(font(for: item))
+                        .minimumScaleFactor(0.7)
+                        .multilineTextAlignment(.center)
+                        .foregroundStyle(DSColor.primaryButtonForeground)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 58)
+                        .background(backgroundColor(for: item))
+                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                }
+                .buttonStyle(.plain)
+                .disabled(isSolving)
+            }
+        }
+    }
+
+    private func tap(_ item: ManualKeypadItem) {
+        switch item {
+        case .digit(let digit):
+            onTapDigit(digit)
+        case .action(let action):
+            switch action {
+            case .clean:
+                onTapClean()
+            case .delete:
+                onTapDelete()
+            case .solve:
+                onTapSolve()
+            }
+        }
+    }
+
+    private func title(for item: ManualKeypadItem) -> String {
+        switch item {
+        case .digit(let digit):
+            return String(digit)
+        case .action(let action):
+            switch action {
+            case .clean:
+                return L10n.Manual.clean.localized
+            case .delete:
+                return L10n.Manual.delete.localized
+            case .solve:
+                return L10n.Manual.solve.localized
+            }
+        }
+    }
+
+    private func font(for item: ManualKeypadItem) -> Font {
+        switch item {
+        case .digit:
+            return .system(size: 26, weight: .bold, design: .rounded)
+        case .action:
+            return .system(size: 18, weight: .semibold, design: .rounded)
+        }
+    }
+
+    private func backgroundColor(for item: ManualKeypadItem) -> Color {
+        switch item {
+        case .digit(let digit):
+            if blockedDigits.contains(digit) {
+                return DSColor.manualBlockedDigitButton
+            }
+            return DSColor.primaryButton
+
+        case .action(let action):
+            switch action {
+            case .solve:
+                return DSColor.title
+            case .clean, .delete:
+                return DSColor.primaryButton
+            }
+        }
+    }
+}
+
+private struct ManualSolveLoadingOverlay: View {
+    var body: some View {
+        ZStack {
+            DSColor.loadingScrim
+                .ignoresSafeArea()
+
+            VStack(spacing: 12) {
+                ProgressView()
+                    .progressViewStyle(.circular)
+                Text(L10n.Manual.solving.localized)
+                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    .foregroundStyle(.black)
+            }
+            .padding(.horizontal, 28)
+            .padding(.vertical, 20)
+            .background(Color.white)
+            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+    }
+}
+
+private enum ManualKeypadItem: Hashable {
+    case digit(Int)
+    case action(ManualKeypadAction)
+}
+
+private enum ManualKeypadAction: Hashable {
+    case clean
+    case delete
+    case solve
+}

--- a/Sudoku/FeatureManualSolve/ManualSolveViewModel.swift
+++ b/Sudoku/FeatureManualSolve/ManualSolveViewModel.swift
@@ -1,0 +1,216 @@
+import Foundation
+import SwiftUI
+
+final class ManualSolveViewModel: ObservableObject {
+    enum AlertKind: Identifiable {
+        case cleanConfirm
+        case insufficientDigits
+        case unsolvable
+        case emptyBoard
+
+        var id: String {
+            switch self {
+            case .cleanConfirm:
+                return "cleanConfirm"
+            case .insufficientDigits:
+                return "insufficientDigits"
+            case .unsolvable:
+                return "unsolvable"
+            case .emptyBoard:
+                return "emptyBoard"
+            }
+        }
+    }
+
+    @Published private(set) var board: [Int]
+    @Published private(set) var conflictingIndices: Set<Int>
+    @Published private(set) var highlightedIndices: Set<Int>
+    @Published private(set) var blockedDigits: Set<Int>
+    @Published private(set) var isSolving: Bool
+    @Published var selectedIndex: Int?
+    @Published var alertKind: AlertKind?
+
+    private let boardSolver: SudokuBoardSolving
+
+    init(boardSolver: SudokuBoardSolving = LegacySudokuBoardSolver()) {
+        self.boardSolver = boardSolver
+        self.board = Array(repeating: 0, count: 81)
+        self.conflictingIndices = []
+        self.highlightedIndices = []
+        self.blockedDigits = []
+        self.isSolving = false
+        self.selectedIndex = nil
+        self.alertKind = nil
+        recalculateDerivedState()
+    }
+
+    func selectCell(at index: Int) {
+        guard index >= 0, index < 81 else { return }
+        selectedIndex = index
+        recalculateDerivedState()
+    }
+
+    func inputDigit(_ digit: Int) {
+        guard let selectedIndex else { return }
+        guard (1...9).contains(digit) else { return }
+        board[selectedIndex] = digit
+        recalculateDerivedState()
+    }
+
+    func deleteSelectedCellValue() {
+        guard let selectedIndex else { return }
+        board[selectedIndex] = 0
+        recalculateDerivedState()
+    }
+
+    func requestCleanBoard() {
+        alertKind = .cleanConfirm
+    }
+
+    func clearBoard() {
+        board = Array(repeating: 0, count: 81)
+        selectedIndex = nil
+        recalculateDerivedState()
+    }
+
+    func solveButtonTapped() {
+        guard !isSolving else { return }
+        guard board.contains(where: { $0 != 0 }) else {
+            alertKind = .emptyBoard
+            return
+        }
+
+        if board.filter({ $0 != 0 }).count < 17 {
+            alertKind = .insufficientDigits
+            return
+        }
+
+        solveCurrentBoard()
+    }
+
+    func solveIgnoringMinimumDigits() {
+        guard !isSolving else { return }
+        solveCurrentBoard()
+    }
+
+    private func solveCurrentBoard() {
+        isSolving = true
+        let boardSnapshot = boardMatrix(from: board)
+
+        DispatchQueue.global(qos: .userInitiated).async { [boardSolver] in
+            let result = boardSolver.solve(board: boardSnapshot, iterationLimit: 1_000_000)
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.isSolving = false
+                switch result {
+                case .success(let solvedBoard):
+                    self.board = solvedBoard.flatMap { $0 }
+                    self.recalculateDerivedState()
+                case .failure:
+                    self.alertKind = .unsolvable
+                }
+            }
+        }
+    }
+
+    private func recalculateDerivedState() {
+        conflictingIndices = Self.makeConflictingIndices(from: board)
+
+        if let selectedIndex {
+            highlightedIndices = Self.makeRelatedIndices(for: selectedIndex)
+            blockedDigits = Self.makeBlockedDigits(for: selectedIndex, from: board)
+        } else {
+            highlightedIndices = []
+            blockedDigits = []
+        }
+    }
+
+    private func boardMatrix(from board: [Int]) -> [[Int]] {
+        stride(from: 0, to: board.count, by: 9).map { offset in
+            Array(board[offset..<(offset + 9)])
+        }
+    }
+
+    private static func makeConflictingIndices(from board: [Int]) -> Set<Int> {
+        var conflicts = Set<Int>()
+
+        for row in 0..<9 {
+            mergeDuplicateIndices(indicesInRow(row), from: board, into: &conflicts)
+        }
+
+        for col in 0..<9 {
+            mergeDuplicateIndices(indicesInColumn(col), from: board, into: &conflicts)
+        }
+
+        for boxRow in 0..<3 {
+            for boxCol in 0..<3 {
+                mergeDuplicateIndices(indicesInBox(row: boxRow, col: boxCol), from: board, into: &conflicts)
+            }
+        }
+
+        return conflicts
+    }
+
+    private static func mergeDuplicateIndices(_ indices: [Int], from board: [Int], into conflicts: inout Set<Int>) {
+        var groupedByDigit: [Int: [Int]] = [:]
+
+        for index in indices {
+            let digit = board[index]
+            guard digit != 0 else { continue }
+            groupedByDigit[digit, default: []].append(index)
+        }
+
+        for duplicateIndices in groupedByDigit.values where duplicateIndices.count > 1 {
+            conflicts.formUnion(duplicateIndices)
+        }
+    }
+
+    private static func makeRelatedIndices(for index: Int) -> Set<Int> {
+        let row = index / 9
+        let col = index % 9
+        let boxRow = row / 3
+        let boxCol = col / 3
+
+        var indices = Set(indicesInRow(row))
+        indices.formUnion(indicesInColumn(col))
+        indices.formUnion(indicesInBox(row: boxRow, col: boxCol))
+        return indices
+    }
+
+    private static func makeBlockedDigits(for index: Int, from board: [Int]) -> Set<Int> {
+        let relatedIndices = makeRelatedIndices(for: index)
+        var blockedDigits = Set<Int>()
+
+        for relatedIndex in relatedIndices where relatedIndex != index {
+            let digit = board[relatedIndex]
+            if digit != 0 {
+                blockedDigits.insert(digit)
+            }
+        }
+
+        return blockedDigits
+    }
+
+    private static func indicesInRow(_ row: Int) -> [Int] {
+        (0..<9).map { row * 9 + $0 }
+    }
+
+    private static func indicesInColumn(_ col: Int) -> [Int] {
+        (0..<9).map { $0 * 9 + col }
+    }
+
+    private static func indicesInBox(row boxRow: Int, col boxCol: Int) -> [Int] {
+        let rowStart = boxRow * 3
+        let colStart = boxCol * 3
+        var indices: [Int] = []
+        indices.reserveCapacity(9)
+
+        for row in rowStart..<(rowStart + 3) {
+            for col in colStart..<(colStart + 3) {
+                indices.append(row * 9 + col)
+            }
+        }
+
+        return indices
+    }
+}

--- a/Sudoku/Localization/L10n.swift
+++ b/Sudoku/Localization/L10n.swift
@@ -25,7 +25,23 @@ enum L10n {
         static let routeUnavailableMessage = L10nToken("Please enter Sudoku.")
     }
 
+    enum Manual {
+        static let clean = L10nToken("Clean")
+        static let delete = L10nToken("Delete")
+        static let solve = L10nToken("Solve")
+        static let solving = L10nToken("Currently solving Sudoku")
+        static let reallyWantToSolve = L10nToken("Really want to Solve?")
+        static let requiresMoreThan17 = L10nToken("Sudoku Solve requires more than 17 numbers.")
+        static let cannotSolve = L10nToken("Cannot solve Sudoku.")
+        static let reenterSudoku = L10nToken("Do you want to re-enter Sudoku?")
+        static let cleanSudoku = L10nToken("Clean Sudoku.")
+        static let sudokuNotEntered = L10nToken("Sudoku has not Entered.")
+    }
+
     enum Common {
+        static let yes = L10nToken("Yes")
+        static let no = L10nToken("No")
+        static let cancel = L10nToken("Cancel")
         static let confirm = L10nToken("Confirm")
     }
 }

--- a/Tests/AppShellTests/AppShellRouteConfigTests.swift
+++ b/Tests/AppShellTests/AppShellRouteConfigTests.swift
@@ -1,9 +1,9 @@
 import XCTest
 
 final class AppShellRouteConfigTests: XCTestCase {
-    func testLegacyFlowStoryboardsDeclareInitialViewController() throws {
+    func testLegacyBridgeStoryboardsDeclareInitialViewController() throws {
         let root = repositoryRootURL()
-        let expectedStoryboards = ["photoSudoku", "pickerSudoku", "importSudoku"]
+        let expectedStoryboards = ["photoSudoku", "pickerSudoku"]
 
         for storyboardName in expectedStoryboards {
             let storyboardPath = root
@@ -19,7 +19,7 @@ final class AppShellRouteConfigTests: XCTestCase {
         }
     }
 
-    func testMainStoryboardReferencesAllLegacyFlows() throws {
+    func testMainStoryboardReferencesLegacyBridgeFlows() throws {
         let mainStoryboardPath = repositoryRootURL()
             .appendingPathComponent("Sudoku")
             .appendingPathComponent("StoryBoard")
@@ -29,7 +29,6 @@ final class AppShellRouteConfigTests: XCTestCase {
 
         XCTAssertTrue(xml.contains("storyboardName=\"photoSudoku\""))
         XCTAssertTrue(xml.contains("storyboardName=\"pickerSudoku\""))
-        XCTAssertTrue(xml.contains("storyboardName=\"importSudoku\""))
     }
 
     private func repositoryRootURL(filePath: StaticString = #filePath) -> URL {

--- a/planning/MIGRATION_PLAN.md
+++ b/planning/MIGRATION_PLAN.md
@@ -122,8 +122,8 @@ Last updated: 2026-02-25
 ## P3) 기능별 SwiftUI 마이그레이션
 
 ### P3-1. Manual Solve (우선)
-- [ ] 입력 그리드/키패드 UI를 SwiftUI로 구현
-- [ ] 충돌 강조, 삭제/초기화, solve UX 동일 기능 이관
+- [x] 입력 그리드/키패드 UI를 SwiftUI로 구현 (`FeatureManualSolve`)
+- [x] 충돌 강조, 삭제/초기화, solve UX 동일 기능 이관
 - [ ] 기존 UIKit 화면 제거
 
 ### P3-2. Image Solve (2순위)


### PR DESCRIPTION
## Outline
- P3 시작: Manual 입력 플로우를 SwiftUI 기반으로 1차 전환
- Home에서 `Direct Input` 경로를 UIKit storyboard 브리지 대신 SwiftUI 화면으로 연결

## Work Contents
- `FeatureManualSolve` 추가
  - `Sudoku/FeatureManualSolve/ManualSolveView.swift`
  - `Sudoku/FeatureManualSolve/ManualSolveViewModel.swift`
- Manual 플로우 SwiftUI 구현
  - 9x9 입력 그리드 + 숫자 키패드(1~9/Clean/Delete/Solve)
  - 선택 셀 관련 영역 하이라이트(행/열/박스)
  - 충돌 셀 강조(중복 입력 감지)
  - `Delete`, `Clean`, `Solve` 액션 및 기존 alert UX 이관
  - solve 연산은 백그라운드 큐에서 수행 + 로딩 오버레이 표시
- Home 라우팅 전환
  - `Sudoku/FeatureHome/HomeView.swift`
  - `.manual`은 `ManualSolveView`로 이동
  - camera/picker는 기존 `UIViewControllerRepresentable` 브리지 유지
- 공통 리소스 확장
  - `Sudoku/DesignSystem/DSColor.swift` (Manual 화면 상태 색상)
  - `Sudoku/Localization/L10n.swift` (Manual/공통 토큰 추가)
- App shell route 테스트를 현재 구조와 정합되게 조정
  - `Tests/AppShellTests/AppShellRouteConfigTests.swift`
  - legacy bridge 대상으로 camera/picker만 검증
- 마이그레이션 계획 진행률 업데이트
  - `planning/MIGRATION_PLAN.md`
  - P3-1의 UI/UX 이관 항목 체크

## Test
- `swift test`
- `xcodebuild -project Sudoku.xcodeproj -scheme Sudoku -configuration Debug -destination 'generic/platform=iOS Simulator' build`
- `xcodebuild -project Sudoku.xcodeproj -scheme Sudoku -configuration Debug -destination 'generic/platform=iOS' build`
- `xcodebuild -project Sudoku.xcodeproj -scheme Sudoku -configuration Release -destination 'generic/platform=iOS Simulator' build`
- `xcodebuild -project Sudoku.xcodeproj -scheme Sudoku -configuration Release -destination 'generic/platform=iOS' build`

## Note
- 이번 PR은 P3-1 착수 범위입니다. `importSudokuViewController` 제거는 후속 PR에서 진행 예정입니다.
- `Framework/opencv2.framework.zip` 로컬 변경은 본 PR에 포함하지 않음(기존 워크트리 유지)
