### PR TITLE
fix: PR #58 리뷰 코멘트 후속 반영

### DIFF
--- a/Sudoku/FeatureCameraSolve/CameraSolveView.swift
+++ b/Sudoku/FeatureCameraSolve/CameraSolveView.swift
@@ -139,7 +139,9 @@ struct CameraSolveView: View {
                 primaryButton: .default(Text(L10n.Common.yes.localized)) {
                     viewModel.solveIgnoringMinimumDigits()
                 },
-                secondaryButton: .destructive(Text(L10n.Common.no.localized))
+                secondaryButton: .destructive(Text(L10n.Common.no.localized)) {
+                    viewModel.cancelSolveAndResumeCamera()
+                }
             )
 
         case .solveFailed:

--- a/Sudoku/FeatureCameraSolve/CameraSolveViewModel.swift
+++ b/Sudoku/FeatureCameraSolve/CameraSolveViewModel.swift
@@ -92,6 +92,14 @@ final class CameraSolveViewModel: ObservableObject {
         startSolve(ignoreMinimumDigits: true, sourceImage: pendingSolveImage)
     }
 
+    func cancelSolveAndResumeCamera() {
+        invalidateSolveToken()
+        isSolving = false
+        primaryButtonMode = .shoot
+        pendingSolveImage = nil
+        configureAndStartCamera()
+    }
+
     func openSettings() {
         guard let settingURL = URL(string: UIApplication.openSettingsURLString) else { return }
         UIApplication.shared.open(settingURL)

--- a/Sudoku/FeatureImageSolve/ImageSolveViewModel.swift
+++ b/Sudoku/FeatureImageSolve/ImageSolveViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Photos
 import UIKit
 
 final class ImageSolveViewModel: ObservableObject {

--- a/Sudoku/FeatureShared/SudokuBoardOverlayRenderer.swift
+++ b/Sudoku/FeatureShared/SudokuBoardOverlayRenderer.swift
@@ -12,7 +12,7 @@ enum SudokuBoardOverlayRenderer {
         let cellHeight = boardSize.height / 9
 
         let renderer = UIGraphicsImageRenderer(size: boardSize)
-        return renderer.image { context in
+        return renderer.image { _ in
             image.draw(in: CGRect(origin: .zero, size: boardSize))
 
             for row in 0..<9 {

--- a/Sudoku/Localization/L10n.swift
+++ b/Sudoku/Localization/L10n.swift
@@ -45,7 +45,7 @@ enum L10n {
         static let solvingSudoku = L10nToken("Currently solving Sudoku")
         static let retryTitle = L10nToken("Fail.")
         static let retryMessage = L10nToken("Take a Picture Again.")
-        static let permissionDeniedMessage = L10nToken("If didn't allow the camera permission, \r\n Would like to go to the Setting Screen?")
+        static let permissionDeniedMessage = L10nToken("Camera access is disabled.\nWould you like to open Settings?")
     }
 
     enum Image {
@@ -54,7 +54,7 @@ enum L10n {
         static let imageMissingTitle = L10nToken("Picture hasn't been Uploaded.")
         static let imageMissingMessage = L10nToken("Want to Upload a Picture?")
         static let retryMessage = L10nToken("Upload another Picture?")
-        static let albumPermissionDeniedMessage = L10nToken("Soldoku is not allowed access to Album. \r\n Do you want to go to the Setting Screen?")
+        static let albumPermissionDeniedMessage = L10nToken("SolDoKu cannot access your album.\nWould you like to open Settings?")
     }
 
     enum Settings {

--- a/Tests/AppShellTests/AppShellRouteConfigTests.swift
+++ b/Tests/AppShellTests/AppShellRouteConfigTests.swift
@@ -50,6 +50,23 @@ final class AppShellRouteConfigTests: XCTestCase {
         XCTAssertFalse(source.contains("importSudoku.storyboard in Resources"))
     }
 
+    func testCameraInsufficientDigitsNoActionResumesPreview() throws {
+        let cameraViewPath = repositoryRootURL()
+            .appendingPathComponent("Sudoku")
+            .appendingPathComponent("FeatureCameraSolve")
+            .appendingPathComponent("CameraSolveView.swift")
+        let cameraViewSource = try String(contentsOf: cameraViewPath, encoding: .utf8)
+        XCTAssertTrue(cameraViewSource.contains("viewModel.cancelSolveAndResumeCamera()"))
+
+        let cameraViewModelPath = repositoryRootURL()
+            .appendingPathComponent("Sudoku")
+            .appendingPathComponent("FeatureCameraSolve")
+            .appendingPathComponent("CameraSolveViewModel.swift")
+        let cameraViewModelSource = try String(contentsOf: cameraViewModelPath, encoding: .utf8)
+        XCTAssertTrue(cameraViewModelSource.contains("func cancelSolveAndResumeCamera()"))
+        XCTAssertTrue(cameraViewModelSource.contains("configureAndStartCamera()"))
+    }
+
     private func repositoryRootURL(filePath: StaticString = #filePath) -> URL {
         URL(fileURLWithPath: "\(filePath)")
             .deletingLastPathComponent() // AppShellTests


### PR DESCRIPTION
## Outline
- 머지된 PR #58에 남아 있던 리뷰 코멘트(미해결 thread) 후속 반영입니다.

## Work Contents
- Camera insufficient-digits 알럿의 `No` 선택 시 카메라 프리뷰가 재개되도록 수정
  - `CameraSolveViewModel.cancelSolveAndResumeCamera()` 추가
  - `CameraSolveView` 알럿 secondary 버튼 액션 연결
- `ImageSolveViewModel`의 unused import(`Photos`) 제거
- 권한 안내 문구 품질 개선
  - 자연스러운 영어 표현으로 교체
  - `\r\n` -> `\n` 정리
  - `Soldoku` 오타를 `SolDoKu`로 수정
- `SudokuBoardOverlayRenderer`의 unused closure 파라미터 제거
- 회귀 방지용 AppShell source test 추가
  - insufficient-digits 거절 시 resume 액션 연결 여부 검증

## Test
- `./scripts/bootstrap_opencv.sh`
- `xcodebuild -project Sudoku.xcodeproj -scheme Sudoku -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project Sudoku.xcodeproj -scheme Sudoku -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project Sudoku.xcodeproj -scheme Sudoku -configuration Release -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project Sudoku.xcodeproj -scheme Sudoku -configuration Release -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- `swift test`
