### PR TITLE
fix: 카메라 실시간 인식 복구 및 앱 버전 2.0.0 반영

### DIFF
--- a/Sudoku.xcodeproj/project.pbxproj
+++ b/Sudoku.xcodeproj/project.pbxproj
@@ -636,7 +636,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.5;
+					MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.coin.SolDoKu;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -676,7 +676,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.5;
+					MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.coin.SolDoKu;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Sudoku.xcodeproj/project.pbxproj
+++ b/Sudoku.xcodeproj/project.pbxproj
@@ -624,8 +624,9 @@
 				INFOPLIST_FILE = Sudoku/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = CFBundleDisplayName;
 				INFOPLIST_KEY_NSCameraUsageDescription = NSCameraUsageDescription;
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = NSPhotoLibraryUsageDescription;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+					INFOPLIST_KEY_NSPhotoLibraryUsageDescription = NSPhotoLibraryUsageDescription;
+					INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
+					INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = UIInterfaceOrientationPortrait;
@@ -664,8 +665,9 @@
 				INFOPLIST_FILE = Sudoku/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = CFBundleDisplayName;
 				INFOPLIST_KEY_NSCameraUsageDescription = NSCameraUsageDescription;
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = NSPhotoLibraryUsageDescription;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+					INFOPLIST_KEY_NSPhotoLibraryUsageDescription = NSPhotoLibraryUsageDescription;
+					INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
+					INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = UIInterfaceOrientationPortrait;

--- a/Sudoku/FeatureCameraSolve/CameraSessionManager.swift
+++ b/Sudoku/FeatureCameraSolve/CameraSessionManager.swift
@@ -7,12 +7,22 @@ final class CameraSessionManager: NSObject, ObservableObject {
     let session = AVCaptureSession()
 
     @Published private(set) var latestFrame: UIImage?
+    @Published private(set) var latestDetectedCorners: [CGPoint]
 
     private var isConfigured = false
     private let configurationQueue = DispatchQueue(label: "com.soldoku.camera.configure")
     private let sampleBufferQueue = DispatchQueue(label: "com.soldoku.camera.sample-buffer")
+    private let cornerDetectionQueue = DispatchQueue(label: "com.soldoku.camera.corner-detection")
     private var lastFrameTimestamp: CFTimeInterval = 0
     private let frameThrottleInterval: CFTimeInterval = 0.12
+    private let cornerDetectionSemaphore = DispatchSemaphore(value: 1)
+    private let visionProcessor: SudokuVisionProcessing
+
+    init(visionProcessor: SudokuVisionProcessing = OpenCVSudokuVisionAdapter()) {
+        self.visionProcessor = visionProcessor
+        self.latestDetectedCorners = []
+        self.latestFrame = nil
+    }
 
     func configureIfNeeded(completion: @escaping (Bool) -> Void) {
         configurationQueue.async {
@@ -112,8 +122,24 @@ extension CameraSessionManager: AVCaptureVideoDataOutputSampleBufferDelegate {
         let frameImage = UIImage(cgImage: cgImage)
         let square = cropToCenterSquare(frameImage)
 
+        detectCornersIfPossible(from: square)
+
         DispatchQueue.main.async {
             self.latestFrame = square
+        }
+    }
+
+    private func detectCornersIfPossible(from image: UIImage) {
+        guard cornerDetectionSemaphore.wait(timeout: .now()) == .success else { return }
+        cornerDetectionQueue.async {
+            defer {
+                self.cornerDetectionSemaphore.signal()
+            }
+            let corners = self.visionProcessor.detectCorners(in: image)
+            DispatchQueue.main.async {
+                guard let corners, corners.count >= 4 else { return }
+                self.latestDetectedCorners = Array(corners.prefix(4))
+            }
         }
     }
 

--- a/Sudoku/FeatureCameraSolve/CameraSolveView.swift
+++ b/Sudoku/FeatureCameraSolve/CameraSolveView.swift
@@ -2,11 +2,9 @@ import SwiftUI
 
 struct CameraSolveView: View {
     @StateObject private var viewModel: CameraSolveViewModel
-    @ObservedObject private var cameraManager: CameraSessionManager
 
     init(viewModel: CameraSolveViewModel = .init()) {
         _viewModel = StateObject(wrappedValue: viewModel)
-        _cameraManager = ObservedObject(wrappedValue: viewModel.cameraManager)
     }
 
     var body: some View {
@@ -65,14 +63,14 @@ struct CameraSolveView: View {
 
     private var cameraPreview: some View {
         ZStack {
-            CameraPreviewView(session: cameraManager.session)
+            CameraPreviewView(session: viewModel.cameraManager.session)
                 .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
 
             if viewModel.solvedImage == nil {
                 GeometryReader { geometry in
                     CameraDetectedRectangleOverlay(
-                        corners: cameraManager.latestDetectedCorners,
-                        sourceImageSize: cameraManager.latestFrame?.size,
+                        corners: viewModel.latestDetectedCorners,
+                        sourceImageSize: viewModel.latestFrameSize,
                         canvasSize: geometry.size
                     )
                 }

--- a/Sudoku/FeatureCameraSolve/CameraSolveViewModel.swift
+++ b/Sudoku/FeatureCameraSolve/CameraSolveViewModel.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import UIKit
 
@@ -26,6 +27,7 @@ final class CameraSolveViewModel: ObservableObject {
 
     @Published private(set) var isSolving: Bool
     @Published private(set) var solvedImage: UIImage?
+    @Published private(set) var recognizedPreviewImage: UIImage?
     @Published private(set) var primaryButtonMode: PrimaryButtonMode
     @Published var alertKind: AlertKind?
 
@@ -36,8 +38,12 @@ final class CameraSolveViewModel: ObservableObject {
     private let puzzleRecognizer: SudokuPuzzleRecognizing
     private let boardSolver: SudokuBoardSolving
 
+    private var frameObservation: AnyCancellable?
     private var pendingSolveImage: UIImage?
     private var activeSolveToken = UUID()
+    private var isLiveRecognitionInProgress = false
+    private var liveRecognitionFrameCounter = 0
+    private let liveRecognitionFrameInterval = 8
 
     init(
         cameraManager: CameraSessionManager = .init(),
@@ -55,9 +61,11 @@ final class CameraSolveViewModel: ObservableObject {
         )
         self.isSolving = false
         self.solvedImage = nil
+        self.recognizedPreviewImage = nil
         self.primaryButtonMode = .shoot
         self.alertKind = nil
         self.pendingSolveImage = nil
+        bindLivePreviewRecognition()
     }
 
     var primaryButtonTitle: String {
@@ -76,6 +84,8 @@ final class CameraSolveViewModel: ObservableObject {
     func onDisappear() {
         invalidateSolveToken()
         isSolving = false
+        recognizedPreviewImage = nil
+        liveRecognitionFrameCounter = 0
         cameraManager.stopRunning()
     }
 
@@ -96,6 +106,8 @@ final class CameraSolveViewModel: ObservableObject {
         invalidateSolveToken()
         isSolving = false
         primaryButtonMode = .shoot
+        recognizedPreviewImage = nil
+        liveRecognitionFrameCounter = 0
         pendingSolveImage = nil
         configureAndStartCamera()
     }
@@ -129,6 +141,70 @@ final class CameraSolveViewModel: ObservableObject {
                 }
             }
         }
+    }
+
+    private func bindLivePreviewRecognition() {
+        frameObservation = cameraManager.$latestFrame
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] frame in
+                guard let self, let frame else { return }
+                self.updateLiveRecognizedPreviewIfNeeded(from: frame)
+            }
+    }
+
+    private func updateLiveRecognizedPreviewIfNeeded(from frame: UIImage) {
+        guard solvedImage == nil,
+              !isSolving,
+              primaryButtonMode == .shoot else {
+            return
+        }
+        guard !isLiveRecognitionInProgress else { return }
+
+        liveRecognitionFrameCounter += 1
+        guard liveRecognitionFrameCounter >= liveRecognitionFrameInterval else { return }
+        liveRecognitionFrameCounter = 0
+
+        guard isDetectedRectangleLargeEnough(cameraManager.latestDetectedCorners) else { return }
+
+        isLiveRecognitionInProgress = true
+        DispatchQueue.global(qos: .userInitiated).async {
+            defer {
+                DispatchQueue.main.async {
+                    self.isLiveRecognitionInProgress = false
+                }
+            }
+
+            guard let detectedRectangle = self.visionProcessor.detectRectangle(in: frame),
+                  let recognitionResult = self.puzzleRecognizer.recognizeBoard(
+                      from: detectedRectangle.warpedImage,
+                      imageSize: 64,
+                      cutOffset: 0
+                  ),
+                  let boardImage = UIImage(named: "sudoku") else {
+                return
+            }
+
+            let previewImage = SudokuBoardOverlayRenderer.drawRecognizedBoard(
+                board: recognitionResult.board,
+                on: boardImage
+            )
+
+            DispatchQueue.main.async {
+                guard self.solvedImage == nil,
+                      !self.isSolving,
+                      self.primaryButtonMode == .shoot else { return }
+                self.recognizedPreviewImage = previewImage
+            }
+        }
+    }
+
+    private func isDetectedRectangleLargeEnough(_ corners: [CGPoint]) -> Bool {
+        guard corners.count >= 4 else { return false }
+        let valueX = corners[0].x - corners[3].x
+        let valueY = corners[0].y - corners[1].y
+        let valueX2 = corners[1].x - corners[2].x
+        let valueY2 = corners[2].y - corners[3].y
+        return abs(valueX) > 100 && abs(valueY) > 100 && abs(valueX2) > 100 && abs(valueY2) > 100
     }
 
     private func startSolve(ignoreMinimumDigits: Bool, sourceImage: UIImage?) {
@@ -200,6 +276,8 @@ final class CameraSolveViewModel: ObservableObject {
     private func resetToCameraPreview() {
         invalidateSolveToken()
         solvedImage = nil
+        recognizedPreviewImage = nil
+        liveRecognitionFrameCounter = 0
         primaryButtonMode = .shoot
         pendingSolveImage = nil
         configureAndStartCamera()

--- a/Sudoku/FeatureHome/HomeView.swift
+++ b/Sudoku/FeatureHome/HomeView.swift
@@ -4,6 +4,7 @@ struct HomeView: View {
     @State private var selectedPreviewIndex: Int?
     @State private var highlightedPreviewIndices: Set<Int> = []
     @State private var pressedPreviewIndex: Int?
+    @State private var releasePressedPreviewWorkItem: DispatchWorkItem?
 
     var body: some View {
         NavigationStack {
@@ -75,12 +76,15 @@ struct HomeView: View {
             pressedPreviewIndex = index
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        releasePressedPreviewWorkItem?.cancel()
+        let workItem = DispatchWorkItem {
             guard pressedPreviewIndex == index else { return }
             withAnimation(.easeOut(duration: 0.1)) {
                 pressedPreviewIndex = nil
             }
         }
+        releasePressedPreviewWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: workItem)
     }
 
     private static func makeHighlightedIndices(for selectedIndex: Int) -> Set<Int> {

--- a/Sudoku/FeatureManualSolve/ManualSolveView.swift
+++ b/Sudoku/FeatureManualSolve/ManualSolveView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ManualSolveView: View {
     @StateObject private var viewModel: ManualSolveViewModel
     @State private var pressedCellIndex: Int?
+    @State private var releasePressedCellWorkItem: DispatchWorkItem?
 
     init(viewModel: ManualSolveViewModel = .init()) {
         _viewModel = StateObject(wrappedValue: viewModel)
@@ -115,12 +116,15 @@ struct ManualSolveView: View {
             pressedCellIndex = index
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        releasePressedCellWorkItem?.cancel()
+        let workItem = DispatchWorkItem {
             guard pressedCellIndex == index else { return }
             withAnimation(.easeOut(duration: 0.1)) {
                 pressedCellIndex = nil
             }
         }
+        releasePressedCellWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: workItem)
     }
 }
 

--- a/Sudoku/FeatureManualSolve/ManualSolveView.swift
+++ b/Sudoku/FeatureManualSolve/ManualSolveView.swift
@@ -2,9 +2,11 @@ import SwiftUI
 
 struct ManualSolveView: View {
     @StateObject private var viewModel: ManualSolveViewModel
+    @State private var pressedCellIndex: Int?
 
     init(viewModel: ManualSolveViewModel = .init()) {
         _viewModel = StateObject(wrappedValue: viewModel)
+        _pressedCellIndex = State(initialValue: nil)
     }
 
     var body: some View {
@@ -15,9 +17,10 @@ struct ManualSolveView: View {
                     selectedIndex: viewModel.selectedIndex,
                     highlightedIndices: viewModel.highlightedIndices,
                     conflictingIndices: viewModel.conflictingIndices,
+                    pressedIndex: pressedCellIndex,
                     onTapCell: { index in
                         if !viewModel.isSolving {
-                            viewModel.selectCell(at: index)
+                            handleCellTap(index)
                         }
                     }
                 )
@@ -104,6 +107,21 @@ struct ManualSolveView: View {
             )
         }
     }
+
+    private func handleCellTap(_ index: Int) {
+        viewModel.selectCell(at: index)
+
+        withAnimation(.easeOut(duration: 0.1)) {
+            pressedCellIndex = index
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            guard pressedCellIndex == index else { return }
+            withAnimation(.easeOut(duration: 0.1)) {
+                pressedCellIndex = nil
+            }
+        }
+    }
 }
 
 private struct ManualSudokuGrid: View {
@@ -111,6 +129,7 @@ private struct ManualSudokuGrid: View {
     let selectedIndex: Int?
     let highlightedIndices: Set<Int>
     let conflictingIndices: Set<Int>
+    let pressedIndex: Int?
     let onTapCell: (Int) -> Void
 
     var body: some View {
@@ -132,6 +151,7 @@ private struct ManualSudokuGrid: View {
                                 .background(backgroundColor(for: index))
                         }
                         .buttonStyle(.plain)
+                        .scaleEffect(pressedIndex == index ? 0.9 : 1.0)
                     }
                 }
 


### PR DESCRIPTION
## Outline
- 카메라 촬영 화면에서 누락된 실시간 인식 UI(사각형 오버레이, 하단 인식 숫자 프리뷰)를 복구했습니다.
- 직접 입력하기 화면에 메인 화면과 동일한 칸 클릭 피드백(press animation) 로직을 적용했습니다.
- 앱 버전을 `2.0.0`으로 상향했습니다.

## Work Contents
- `FeatureCameraSolve` 실시간 인식 표시 복구
  - `CameraSessionManager`에 corners publish 추가 및 비동기 코너 인식 파이프라인 보강
  - `CameraSolveView`에서 프리뷰 위 사각형 오버레이 렌더링 복구
  - `CameraSolveViewModel`에 live recognition 루프 추가
    - 프레임 구독 기반 하단 보드 숫자 프리뷰 갱신
    - 레거시와 동일한 크기 조건 필터 적용
- `FeatureManualSolve` 탭 피드백 보강
  - 셀 탭 시 0.1초 press scale animation 적용
- 버전 업데이트
  - `MARKETING_VERSION`을 `2.0.0`으로 변경

## Test
- `xcodebuild -project Sudoku.xcodeproj -scheme Sudoku -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- `swift test`
- `xcodebuild -project Sudoku.xcodeproj -scheme Sudoku -showBuildSettings | rg "MARKETING_VERSION|CURRENT_PROJECT_VERSION"`

## Notes
- 확인된 빌드 설정 기준 버전은 `MARKETING_VERSION = 2.0.0` 입니다.
