### PR TITLE
chore: bump app version to 2.1.0

### DIFF
--- a/Sudoku.xcodeproj/project.pbxproj
+++ b/Sudoku.xcodeproj/project.pbxproj
@@ -612,7 +612,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 5N5TS7Y4MA;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -642,7 +642,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-					MARKETING_VERSION = 2.0.0;
+					MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.coin.SolDoKu;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -660,7 +660,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 5N5TS7Y4MA;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -690,7 +690,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-					MARKETING_VERSION = 2.0.0;
+					MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.coin.SolDoKu;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
## Summary
- bump MARKETING_VERSION to 2.1.0
- bump CURRENT_PROJECT_VERSION to 2 for the next App Store build

## Verification
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project Sudoku.xcodeproj -scheme Sudoku -showBuildSettings
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project Sudoku.xcodeproj -scheme Sudoku -configuration Release -destination 'generic/platform=iOS' -archivePath /tmp/SolDoKuRelease/Sudoku-2.1.0.xcarchive -allowProvisioningUpdates archive